### PR TITLE
Fix TLS handshake error

### DIFF
--- a/Default.txt
+++ b/Default.txt
@@ -8,6 +8,7 @@ persist-key
 persist-tun
 key-direction 1
 remote-cert-tls server
+tls-version-min 1.2
 verify-x509-name SRVRNAME name
 cipher AES-256-CBC
 auth SHA256


### PR DESCRIPTION
When connecting with Tunnelblick client I received following error:
```
TLS_ERROR: BIO read tls_read_plaintext error: error:140760FC:SSL routines:SSL23_GET_CLIENT_HELLO:unknown protocol
TLS Error: TLS object -> incoming plaintext read error
TLS Error: TLS handshake failed
```

To fix the problem the same **tls-version-min** directive used in server configuration has to be added to the client config.