### PR TITLE
Randomize DH params fetched from 2ton.com.au

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -746,7 +746,8 @@ confOpenVPN() {
     if ([ "$ENCRYPT" -ge "4096" ] && whiptail --backtitle "Setup OpenVPN" --title "Diffie-Hellman Parameters" --defaultno --yesno "Generating Diffie-Hellman parameters for a $ENCRYPT-bits key might take a long time on a Raspberry Pi. Do you want to download them? (If you're paranoid, choose 'No')" $r $c)
 then
     # Downloading parameters, $KEY_DIR and $KEY_SIZE get set by sourcing ./vars
-    ${SUDOE} curl "https://2ton.com.au/dhparam/${ENCRYPT}" -o "${KEY_DIR}/dh${KEY_SIZE}.pem"
+    RANDOM_INDEX=$(( RANDOM % 128 ))
+    ${SUDOE} curl "https://2ton.com.au/dhparam/${ENCRYPT}/${RANDOM_INDEX}" -o "${KEY_DIR}/dh${KEY_SIZE}.pem"
 else
     # Generate Diffie-Hellman key exchange
     ${SUDOE} ./build-dh


### PR DESCRIPTION
Fetch random DH params from the last 128 generated by 2ton.com.au. This will reduce the likelihood that multiple installs in short period of time will share the same DH params.