### PR TITLE
Fixed links in README.md on lines 156 and 158

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,9 @@ sources.
 
 2. And the code at [pi-hole.net](https://github.com/pi-hole/pi-hole)
 
-3. Of course there is [OpenVPN] (https://openvpn.net)
+3. Of course there is [OpenVPN](https://openvpn.net)
 
-4. And as always the ever vigilant [EFF] (https://www.eff.org/)
+4. And as always the ever vigilant [EFF](https://www.eff.org/)
 
 I don't take donations at this time but if you want to show your appreciation to me, then contribute or leave feedback on suggestions or improvements.
 


### PR DESCRIPTION
A extremely trivial issue. Markdown doesn't consider them links because of the space.