### PR TITLE
Generate and activate CRL during installation

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -886,8 +886,8 @@ EOF
 
     # Generate an empty Certificate Revocation List
     ${SUDOE} ./easyrsa gen-crl
-    cp pki/crl.pem /etc/openvpn/crl.pem
-    chown nobody:nogroup /etc/openvpn/crl.pem
+    ${SUDOE} cp pki/crl.pem /etc/openvpn/crl.pem
+    ${SUDOE} chown nobody:nogroup /etc/openvpn/crl.pem
 
     # Write config file for server using the template .txt file
     $SUDO cp /etc/.pivpn/server_config.txt /etc/openvpn/server.conf

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -884,6 +884,11 @@ EOF
     # Generate static HMAC key to defend against DDoS
     ${SUDOE} openvpn --genkey --secret pki/ta.key
 
+    # Generate an empty Certificate Revocation List
+    ${SUDOE} ./easyrsa gen-crl
+    cp pki/crl.pem /etc/openvpn/crl.pem
+    chown nobody:nogroup /etc/openvpn/crl.pem
+
     # Write config file for server using the template .txt file
     $SUDO cp /etc/.pivpn/server_config.txt /etc/openvpn/server.conf
 
@@ -991,10 +996,6 @@ confOVPN() {
     fi
     $SUDO cp /tmp/pivpnUSR /etc/pivpn/INSTALL_USER
     $SUDO cp /tmp/DET_PLATFORM /etc/pivpn/DET_PLATFORM
-
-    # Set status that no certs have been revoked
-    echo 0 > /tmp/REVOKE_STATUS
-    $SUDO cp /tmp/REVOKE_STATUS /etc/pivpn/REVOKE_STATUS
 
     $SUDO cp /etc/.pivpn/Default.txt /etc/openvpn/easy-rsa/pki/Default.txt
 

--- a/scripts/removeOVPN.sh
+++ b/scripts/removeOVPN.sh
@@ -105,22 +105,6 @@ fi
 
 cd /etc/openvpn/easy-rsa || exit
 
-if [ "${REVOKE_STATUS}" == 0 ]; then
-    echo 1 > /etc/pivpn/REVOKE_STATUS
-    printf "\nThis seems to be the first time you have revoked a cert.\n"
-    printf "First we need to initialize the Certificate Revocation List.\n"
-    printf "Then add the CRL to your server config and restart openvpn.\n"
-    ./easyrsa gen-crl
-    cp pki/crl.pem /etc/openvpn/crl.pem
-    chown nobody:nogroup /etc/openvpn/crl.pem
-    sed -i '/#crl-verify/c\crl-verify /etc/openvpn/crl.pem' /etc/openvpn/server.conf
-    if [[ ${PLAT} == "Ubuntu" || ${PLAT} == "Debian" ]]; then
-        service openvpn restart
-    else
-        systemctl restart openvpn.service
-    fi
-fi
-
 for (( ii = 0; ii < ${#CERTS_TO_REVOKE[@]}; ii++)); do
     printf "\n::: Revoking certificate '"%s"'.\n" "${CERTS_TO_REVOKE[ii]}"
     ./easyrsa --batch revoke "${CERTS_TO_REVOKE[ii]}"

--- a/scripts/removeOVPN.sh
+++ b/scripts/removeOVPN.sh
@@ -2,7 +2,6 @@
 # PiVPN: revoke client script
 
 INSTALL_USER=$(cat /etc/pivpn/INSTALL_USER)
-REVOKE_STATUS=$(cat /etc/pivpn/REVOKE_STATUS)
 PLAT=$(cat /etc/pivpn/DET_PLATFORM)
 INDEX="/etc/openvpn/easy-rsa/pki/index.txt"
 

--- a/server_config.txt
+++ b/server_config.txt
@@ -34,7 +34,7 @@ user nobody
 group nogroup
 persist-key
 persist-tun
-#crl-verify /etc/openvpn/crl.pem
+crl-verify /etc/openvpn/crl.pem
 status /var/log/openvpn-status.log 20
 status-version 3
 log /var/log/openvpn.log


### PR DESCRIPTION
Implemented that an empty certificate revocation list is generated during installation after generation of other parts of the Public Key Infrastructure. The added benefit of this is that whenever the user now revokes a client, the change is instant. Whereas before, the first time a revocation happened since the installation of PiVPN, the OpenVPN server had to be restarted to enable the then-newly-generated CRL (causing an interruption of service for other connected clients). This change also makes the file /etc/pivpn/REVOKE_STATUS obsolete.

Documentation: https://openvpn.net/index.php/open-source/documentation/howto.html#revoke