### PR TITLE
Randomize server Common Name for added security

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -797,7 +797,9 @@ setClientDNS() {
 }
 
 confOpenVPN() {
-    SERVER_NAME="server"
+    # Generate a random, alphanumeric identifier of 16 characters for this server so that we can use verify-x509-name later that is unique for this server installation. Source: Earthgecko (https://gist.github.com/earthgecko/3089509)
+    NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+    SERVER_NAME="server_${NEW_UUID}"
 
     if [[ ${useUpdateVars} == false ]]; then
         # Ask user for desired level of encryption
@@ -859,7 +861,7 @@ EOF
     fi
 
     # Build the server
-    ${SUDOE} ./easyrsa build-server-full server nopass
+    ${SUDOE} ./easyrsa build-server-full ${SERVER_NAME} nopass
 
     if [[ ${useUpdateVars} == false ]]; then
         if ([ "$ENCRYPT" -ge "4096" ] && whiptail --backtitle "Setup OpenVPN" --title "Download Diffie-Hellman Parameters" --yesno --defaultno "Download Diffie-Hellman parameters from a public DH parameter generation service?\n\nGenerating DH parameters for a $ENCRYPT-bit key can take many hours on a Raspberry Pi. You can instead download DH parameters from \"2 Ton Digital\" that are generated at regular intervals as part of a public service. Downloaded DH parameters will be randomly selected from a pool of the last 128 generated.\nMore information about this service can be found here: https://2ton.com.au/dhtool/\n\nIf you're paranoid, choose 'No' and Diffie-Hellman parameters will be generated on your device." ${r} ${c})

--- a/server_config.txt
+++ b/server_config.txt
@@ -25,6 +25,7 @@ push "redirect-gateway def1"
 client-to-client
 duplicate-cn
 keepalive 10 120
+remote-cert-tls client
 tls-version-min 1.2
 tls-auth /etc/openvpn/easy-rsa/pki/ta.key 0
 cipher AES-256-CBC


### PR DESCRIPTION
The SERVER_NAME variable is used in a `verify-x509-name` check to allow the client to verify it is talking to the correct server (based on the server certificate Common Name). However, the variable's value was always equal to `server`. This wasn't unique for each installation and therefore provided no additional safety. So I've modified it to be random for each installation of PiVPN.

Additionally, the client config contains the `remote-cert-tls` option to check for appropriate key usage, but the server config didn't so I added it.

Source for obtaining a random UUID (thank you): Earthgecko (https://gist.github.com/earthgecko/3089509)