### PR TITLE
fixed pivpn clients text display

### DIFF
--- a/scripts/clientStat.sh
+++ b/scripts/clientStat.sh
@@ -12,10 +12,10 @@ printf ": NOTE : The output below is NOT real-time!\n"
 printf ":      : It may be off by a few minutes.\n"
 printf "\n"
 printf "\e[1m::: Client Status List :::\e[0m\n"
-printf "\t\t\t\t\t\t\tBytes\t\tBytes\t\n"
-printf "\e[4mName\e[0m\t\t\e[4mRemote IP\e[0m\t\t\e[4mVirtual IP\e[0m\t\e[4mReceived\e[0m\t\e[4mSent\e[0m\t\t\e[4mConnected Since\e[0m \n"
+printf "\t\t\t\t\t\t\t\tBytes\t\tBytes\t\n"
+printf "\e[4mName\e[0m\t\t\t\e[4mRemote IP\e[0m\t\t\e[4mVirtual IP\e[0m\t\e[4mReceived\e[0m\t\e[4mSent\e[0m\t\t\e[4mConnected Since\e[0m \n"
 if grep -q "^CLIENT_LIST" "${STATUS_LOG}"; then
-    awk -F' ' -v s='CLIENT_LIST' '$1 == s {print $2"\t\t"$3"\t"$4"\t"$5"\t\t"$6"\t\t"$8" "$9" "$11" -- "$10}' ${STATUS_LOG}
+    awk -F' ' -v s='CLIENT_LIST' '$1 == s {print $2"\t\t"$3"\t"$4"\t"$5"\t\t"$6"\t\t"$8" "$9" "$11" -- "$10"\n"}' ${STATUS_LOG}
 else
     printf "\nNo Clients Connected!\n"
 fi


### PR DESCRIPTION
Fixes titles in pivpn clients not being properly aligned. 
Fixes connected users information that was being displayed on a single line instead of one line per connected client. 

making PR Directly into master as it is a minor fix to clientStat.sh