### PR TITLE
Fix Clients only in one line

### DIFF
--- a/scripts/clientStat.sh
+++ b/scripts/clientStat.sh
@@ -12,10 +12,10 @@ printf ": NOTE : The output below is NOT real-time!\n"
 printf ":      : It may be off by a few minutes.\n"
 printf "\n"
 printf "\e[1m::: Client Status List :::\e[0m\n"
-printf "\t\t\t\t\t\t\tBytes\t\tBytes\t\n"
-printf "\e[4mName\e[0m\t\t\e[4mRemote IP\e[0m\t\t\e[4mVirtual IP\e[0m\t\e[4mReceived\e[0m\t\e[4mSent\e[0m\t\t\e[4mConnected Since\e[0m \n"
+printf "\t\t\t\t\t\t\t\tBytes\t\tBytes\t\n"
+printf "\e[4mName\e[0m\t\t\t\e[4mRemote IP\e[0m\t\t\e[4mVirtual IP\e[0m\t\e[4mReceived\e[0m\t\e[4mSent\e[0m\t\t\e[4mConnected Since\e[0m \n"
 if grep -q "^CLIENT_LIST" "${STATUS_LOG}"; then
-    awk -F' ' -v s='CLIENT_LIST' '$1 == s {print $2"\t\t"$3"\t"$4"\t"$5"\t\t"$6"\t\t"$8" "$9" "$11" -- "$10}' ${STATUS_LOG}
+    awk -F' ' -v s='CLIENT_LIST' '$1 == s {print $2"\t\t"$3"\t"$4"\t"$5"\t\t"$6"\t\t"$8" "$9" "$11" -- "$10"\n"}' ${STATUS_LOG}
 else
     printf "\nNo Clients Connected!\n"
 fi

--- a/scripts/clientStat.sh
+++ b/scripts/clientStat.sh
@@ -29,7 +29,6 @@ if grep -q "^CLIENT_LIST" "${STATUS_LOG}"; then
         else
                 awk -F' ' -v s='CLIENT_LIST' '$1 == s {print $2"\t\t"$3"\t"$4"\t"$5"\t\t"$6"\t\t"$8" "$9" "$11" - "$10"\n"}' ${STATUS_LOG}
         fi
->>>>>>> ad6f5b6c8b57cf72d22527cff4b2290a40514a47
 else
     printf "\nNo Clients Connected!\n"
 fi

--- a/scripts/clientStat.sh
+++ b/scripts/clientStat.sh
@@ -24,7 +24,7 @@ if grep -q "^CLIENT_LIST" "${STATUS_LOG}"; then
                 while read -r line; do
                         read -r -a array <<< $line
                         [[ ${array[0]} = CLIENT_LIST ]] || continue
-                        printf "%s\t\t%s\t%s\t%s\t\t%s\t\t%s %s %s - %s" ${array[1]} ${array[2]} ${array[3]} $(hr ${array[4]}) $(hr ${array[5]}) ${array[7]} ${array[8]} ${array[10]} ${array[9]}
+                        printf "%s\t\t%s\t%s\t%s\t\t%s\t\t%s %s %s - %s\n" ${array[1]} ${array[2]} ${array[3]} $(hr ${array[4]}) $(hr ${array[5]}) ${array[7]} ${array[8]} ${array[10]} ${array[9]}
                 done <$STATUS_LOG
         else
                 awk -F' ' -v s='CLIENT_LIST' '$1 == s {print $2"\t\t"$3"\t"$4"\t"$5"\t\t"$6"\t\t"$8" "$9" "$11" - "$10"\n"}' ${STATUS_LOG}


### PR DESCRIPTION
pivpn clients script was showing clients in only one line, and titles were not properly aligned. 

Fixed confits due to my local repo not syncing correctly, tested, everything is fine now! 