### PR TITLE
Issue-171: Error using iOS OpenVPN

### DIFF
--- a/scripts/makeOVPN.sh
+++ b/scripts/makeOVPN.sh
@@ -121,6 +121,17 @@ function keyPASS() {
     expect eof
 EOF
 
+    #Convert key to des3
+    KEY_FILE="pki/private/${NAME}${KEY}"
+    expect << EOF
+    set timeout -1
+    spawn openssl rsa -in ${KEY_FILE} -des3 -out ${KEY_FILE}
+    expect "Enter pass phrase" { send "${PASSWD}\r" }
+    expect "Enter PEM pass phrase" { send "${PASSWD}\r" }
+    expect "Verifying - Enter PEM pass phrase" { send "${PASSWD}\r" }
+    expect eof
+EOF
+
     cd pki || exit
 
 }


### PR DESCRIPTION
As @fyellin in the comments, there is some chatter on other groups that some OpenVPN implementations cannot handle client keys that are encrypted with RSA.

If the client key is encrypted, we might re-encrypting the current client key using 3DES.

This commit will convert user client key to 3DES in command `pivpn -a`

P/S: All credits to @fyellin. Many thanks to him.