### PR TITLE
Updated install.sh

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -695,6 +695,7 @@ setClientDNS() {
             Level3 "" off
             DNS.WATCH "" off
             Norton "" off
+	    FamilyShield "" off
             Custom "" off)
 
     if DNSchoices=$("${DNSChoseCmd[@]}" "${DNSChooseOptions[@]}" 2>&1 >/dev/tty)
@@ -731,6 +732,13 @@ setClientDNS() {
             echo "::: Using Norton ConnectSafe servers."
             OVPNDNS1="199.85.126.10"
             OVPNDNS2="199.85.127.10"
+            $SUDO sed -i '0,/\(dhcp-option DNS \)/ s/\(dhcp-option DNS \).*/\1'${OVPNDNS1}'\"/' /etc/openvpn/server.conf
+            $SUDO sed -i '0,/\(dhcp-option DNS \)/! s/\(dhcp-option DNS \).*/\1'${OVPNDNS2}'\"/' /etc/openvpn/server.conf
+            ;;
+	FamilyShield)
+            echo "::: Using FamilyShield servers."
+            OVPNDNS1="208.67.222.123"
+            OVPNDNS2="208.67.220.123"
             $SUDO sed -i '0,/\(dhcp-option DNS \)/ s/\(dhcp-option DNS \).*/\1'${OVPNDNS1}'\"/' /etc/openvpn/server.conf
             $SUDO sed -i '0,/\(dhcp-option DNS \)/! s/\(dhcp-option DNS \).*/\1'${OVPNDNS2}'\"/' /etc/openvpn/server.conf
             ;;

--- a/server_config.txt
+++ b/server_config.txt
@@ -31,4 +31,7 @@ status /var/log/openvpn-status.log 20
 status-version 3
 syslog
 verb 3
+#DuplicateCNs allow access control on a less-granular, per user basis.
+#Remove # if you will manage access by user instead of device. 
+#duplicate-cn
 # Generated for use by PiVPN.io


### PR DESCRIPTION
Added support for FamilyShield DNS from OpenDNS/CISCO. 
With a very minor code change, individuals can now implement restrictions on dangers, disturbing, or otherwise adult oriented content without the need for managed restrictions. 
This is a fairly non-invasive change and will benefit users who intend to use VPN for home or small business uses where access to such material may be undesirable. 