### PR TITLE
Added Optional Duplicate Certificate screen in installer. 

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -798,7 +798,7 @@ setOptDuplicate() {
     DupeCNCmd=(whiptail --separate-output --radiolist "Will certificates be distributed on a per-client or per-device[recommended] basis?" ${r} ${c} 6)
     DupeCNChooseOptions=(Per-Device "" on
             Per-Client "" off)
-    if DupeCNchoices=$("${DupeCNCmd[@]}" "${DCNChooseOptions[@]}" 2>&1 >/dev/tty)
+    if DupeCNchoices=$("${DupeCNCmd[@]}" "${DupeCNChooseOptions[@]}" 2>&1 >/dev/tty)
     then
         case ${DupeCNchoices} in
 	Per-Device)

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -808,9 +808,7 @@ setOptDuplicate() {
 	echo ":: Managing certificates by user."
 	$SUDO sed -i -e 's/#duplicate-cn/duplicate-cn/g' /etc/openvpn/server.conf
 	;;
-    done
-    ;;
-    esac
+        esac
     else
         echo "::: Cancel selected. Exiting..." 
 	exit1

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -793,6 +793,30 @@ setClientDNS() {
     fi
 }
 
+setOptDuplicate() {
+    #Allow the user to choose between allowing or disallowing duplicate certificates. Allows user to manage access on a per-user or per-device basis. Default is off. 
+    DupeCNCmd=(whiptail --separate-output --radiolist "Will certificates be distributed on a per-client or per-device[recommended] basis?" ${r} ${c} 6)
+    DupeCNChooseOptions=(Per-Device "" on
+            Per-Client "" off)
+    if DupeCNchoices=$("${DupeCNCmd[@]}" "${DCNChooseOptions[@]}" 2>&1 >/dev/tty)
+    then
+        case ${DupeCNchoices} in
+	Per-Device)
+	echo "::Managing certificates by device."
+	;;
+	Per-Client)
+	echo ":: Managing certificates by user."
+	$SUDO sed -i -e 's/#duplicate-cn/duplicate-cn/g' /etc/openvpn/server.conf
+	;;
+    done
+    ;;
+    esac
+    else
+        echo "::: Cancel selected. Exiting..." 
+	exit1
+    fi
+}
+	    
 confOpenVPN() {
     # Generate a random, alphanumeric identifier of 16 characters for this server so that we can use verify-x509-name later that is unique for this server installation. Source: Earthgecko (https://gist.github.com/earthgecko/3089509)
     NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
@@ -1168,6 +1192,7 @@ installPiVPN() {
     confNetwork
     confOVPN
     setClientDNS
+    setOptDuplicate
     confLogging
     finalExports
 }
@@ -1404,7 +1429,7 @@ main() {
     echo ":::"
     if [[ "${useUpdateVars}" == false ]]; then
         echo "::: Installation Complete!"
-        echo "::: Now run 'pivpn add' to create an ovpn profile for each of your devices."
+        echo "::: Now run 'pivpn add' to create an ovpn profile for each of your users or devices."
         echo "::: Run 'pivpn help' to see what else you can do!"
         echo "::: It is strongly recommended you reboot after installation."
     else


### PR DESCRIPTION
Often users in a home or business environment may desire to issue VPN certificates on a per-user basis. 
Adding duplicate-cn as an option allows the users to choose the best set-up for them. As the "client-config-dir" option is not currently supported by default, adding this option only empowers our users, and does not detract from their abilities or interfere with other functions. 

Use Cases include: 
* Home where parents may wish to provide one certificate per family member who may have multiple devices and revoke or disable as necessary. (Johnny has a laptop and cellphone. Johnny is grounded, revoke Johnny's certificate.) 
* Business where admins may wish to provide one certificate per user with multiple devices and revoke or disable as necessary. (John has a laptop and cellphone. John is fired, revoke John's certificate.)

While this may be seen as a less desirable option, the default and tagged [recommended] option is for duplicate-cn to be commented out of server-conf.txt. 