### PR TITLE
DNS leak fix in server_config.txt

### DIFF
--- a/server_config.txt
+++ b/server_config.txt
@@ -10,6 +10,8 @@ server 10.8.0.0 255.255.255.0
 # Set your primary domain name server address for clients
 push "dhcp-option DNS 8.8.8.8"
 push "dhcp-option DNS 8.8.4.4"
+# Prevent DNS leaks on Windows
+push "block-outside-dns"
 # Override the Client default gateway by using 0.0.0.0/1 and
 # 128.0.0.0/1 rather than 0.0.0.0/0. This has the benefit of
 # overriding but not wiping out the original default gateway.


### PR DESCRIPTION
Added fix to prevent DNS leak on Windows systems. If the OS on the client side is Linux, this option is ignored by the client.