### PR TITLE
Create TWO_POINT_FOUR file when running unattended

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -848,6 +848,10 @@ EOF
       fi
     fi
 
+    if [[ ${runUnattended} == true ]] && [[ ${APPLY_TWO_POINT_FOUR} == true ]]; then
+      $SUDO touch /etc/pivpn/TWO_POINT_FOUR
+    fi
+
     if [[ ${useUpdateVars} == false ]]; then
       if [[ ${APPLY_TWO_POINT_FOUR} == false ]]; then
         if ([ "$ENCRYPT" -ge "4096" ] && whiptail --backtitle "Setup OpenVPN" --title "Download Diffie-Hellman Parameters" --yesno --defaultno "Download Diffie-Hellman parameters from a public DH parameter generation service?\n\nGenerating DH parameters for a $ENCRYPT-bit key can take many hours on a Raspberry Pi. You can instead download DH parameters from \"2 Ton Digital\" that are generated at regular intervals as part of a public service. Downloaded DH parameters will be randomly selected from a pool of the last 128 generated.\nMore information about this service can be found here: https://2ton.com.au/dhtool/\n\nIf you're paranoid, choose 'No' and Diffie-Hellman parameters will be generated on your device." ${r} ${c}); then


### PR DESCRIPTION
When runUnattended is set to true /etc/pivpn/TWO_POINT_FOUR file is not created because useUpdateVars is set to true and it skips the validation in line 837.