### PR TITLE
Add auth-nocache option to client.

### DIFF
--- a/Default.txt
+++ b/Default.txt
@@ -12,5 +12,6 @@ tls-version-min 1.2
 verify-x509-name SRVRNAME name
 cipher AES-256-CBC
 auth SHA256
+auth-nocache
 comp-lzo
 verb 3


### PR DESCRIPTION
As issue #589 points out, this option is necessary to prevent a warning about caching passwords in memory.