### PR TITLE
fix 'i_do_not_follow_recommendations' behavior + workaround for 'unattended'

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1220,7 +1220,7 @@ main() {
     for var in "$@"; do
         case "$var" in
             "--reconfigure"  ) reconfigure=true;;
-            "--i_do_not_follow_recommendations"   ) skipSpaceCheck=false;;
+            "--i_do_not_follow_recommendations"   ) skipSpaceCheck=true;;
             "--unattended"     ) runUnattended=true;;
         esac
     done

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -949,13 +949,11 @@ confNetwork() {
 }
 
 confOVPN() {
-    IPv4pub=$(dig +short myip.opendns.com @208.67.222.222)
-    if [ $? -ne 0 ] || [ -z "$IPv4pub" ]; then
-        echo "dig failed, now trying to curl whatismyip.akamai.com"
-        if ! IPv4pub=$(curl -s http://whatismyip.akamai.com)
-        then
-            echo "whatismyip.akamai.com failed, please check your internet connection/DNS"
-            exit $?
+    if ! IPv4pub=$(dig +short myip.opendns.com @208.67.222.222) || ! valid_ip "$IPv4pub"; then
+        echo "dig failed, now trying to curl checkip.amazonaws.com"
+        if ! IPv4pub=$(curl -s https://checkip.amazonaws.com) || ! valid_ip "$IPv4pub"; then
+            echo "checkip.amazonaws.com failed, please check your internet connection/DNS"
+            exit 1
         fi
     fi
     $SUDO cp /tmp/pivpnUSR /etc/pivpn/INSTALL_USER

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -48,6 +48,7 @@ r=$(( r < 20 ? 20 : r ))
 c=$(( c < 70 ? 70 : c ))
 
 ######## Undocumented Flags. Shhh ########
+skipDistroCheck=false
 skipSpaceCheck=false
 reconfigure=false
 runUnattended=false
@@ -1213,17 +1214,21 @@ main() {
         fi
     fi
 
-    # Check for supported distribution
-    distro_check
-
     # Check arguments for the undocumented flags
     for var in "$@"; do
         case "$var" in
             "--reconfigure"  ) reconfigure=true;;
-            "--i_do_not_follow_recommendations"   ) skipSpaceCheck=true;;
+            "--i_do_not_follow_recommendations"   ) skipDistroCheck=true ; skipSpaceCheck=true;;
             "--unattended"     ) runUnattended=true;;
         esac
     done
+
+    # Check for supported distribution
+    if [[ "${skipDistroCheck}" == true ]]; then
+        echo "::: --i_do_not_follow_recommendations passed to script, skipping distribution support verification!"
+    else
+        distro_check
+    fi
 
     if [[ -f ${setupVars} ]]; then
         if [[ "${runUnattended}" == true ]]; then


### PR DESCRIPTION
The commits here fix the use of the flag 'i_do_not_follow_recommendations' and propose a workaround for the flag 'unattended'.

The flag 'i_do_not_follow_recommendations' was not doing what it should do: put 'true' in 'skipSpaceCheck' :) .

The flag 'unattended' on a non tested distribution was still printing a whiptail dialog. I only propose a workaround here: if the flag 'i_do_not_follow_recommendations' is used, 'distro_check' function is avoided. A better fix should print only "echo" warnings or errors in the 'distro_check' function.