### PR TITLE
Some enhanced (rights & telekom hybrid)

### DIFF
--- a/scripts/makeOVPN.sh
+++ b/scripts/makeOVPN.sh
@@ -241,6 +241,8 @@ echo "tls-auth Private Key found: $TA"
 # Copy the .ovpn profile to the home directory for convenient remote access
 cp "/etc/openvpn/easy-rsa/pki/$NAME$FILEEXT" "/home/$INSTALL_USER/ovpns/$NAME$FILEEXT"
 chown "$INSTALL_USER" "/home/$INSTALL_USER/ovpns/$NAME$FILEEXT"
+chmod o-r "/etc/openvpn/easy-rsa/pki/$NAME$FILEEXT"
+chmod o-r "/home/$INSTALL_USER/ovpns/$NAME$FILEEXT"
 printf "\n\n"
 printf "========================================================\n"
 printf "\e[1mDone! %s successfully created!\e[0m \n" "$NAME$FILEEXT"

--- a/scripts/pivpnDebug.sh
+++ b/scripts/pivpnDebug.sh
@@ -20,4 +20,16 @@ if [[ ${noUFW} -eq 1 ]]; then
     printf ":::\t\t\t\t\t:::\n::\tOutput of iptables\t\t ::\n:::\t\t\t\t\t:::\n"
     iptables -t nat -L -n -v
 fi
+# Telekom Hybrid Check
+wget -O /tmp/hybcheck http://speedport.ip &>/dev/null
+if grep -Fq "Speedport Pro" /tmp/hybcheck || grep -Fq "Speedport Hybrid" /tmp/hybcheck
+then
+    printf ":::\t\t\t\t\t:::\n::\tTelekom Hybrid Check\t\t ::\n:::\t\t\t\t\t:::\n"
+    echo "Are you using Telekom Hybrid (found a hybrid compatible router)?"
+    echo "If yes and you have problems with the connections you can test the following:"
+    echo "Add 'tun-mtu 1316' in /etc/openvpn/easy-rsa/pki/Default.txt to set a hybrid compatible MTU size (new .ovpn files)."
+    echo "For already existing .ovpn files 'tun-mtu 1316' can also be inserted there manually."
+    echo "With Telekom hybrid connections, you may have to experiment a little with MTU (tun-mtu, link-mtu and mssfix)."
+fi
+rm /tmp/hybcheck
 printf ":::\t\t\t\t\t:::\n::\tDebug Output Complete\t\t ::\n:::\t\t\t\t\t:::\n"

--- a/scripts/removeOVPN.sh
+++ b/scripts/removeOVPN.sh
@@ -114,6 +114,7 @@ for (( ii = 0; ii < ${#CERTS_TO_REVOKE[@]}; ii++)); do
     rm -rf "pki/private/${CERTS_TO_REVOKE[ii]}.key"
     rm -rf "pki/issued/${CERTS_TO_REVOKE[ii]}.crt"
     rm -rf "/home/${INSTALL_USER}/ovpns/${CERTS_TO_REVOKE[ii]}.ovpn"
+    rm -rf "/etc/openvpn/easy-rsa/pki/${CERTS_TO_REVOKE[ii]}.ovpn"
     cp /etc/openvpn/easy-rsa/pki/crl.pem /etc/openvpn/crl.pem
 done
 printf "::: Completed!\n"


### PR DESCRIPTION
right adjustment
- read for "other" withdrawn from .ovpn files
- delete also /etc/openvpn/easy-rsa/pki/${CERTS_TO_REVOKE[ii]}.ovpn after remove certificate

Telekom Hybrid Check 
- Small check whether Telekom Hybrid will be used to give helpful tips.