### PR TITLE
Adding support for custom search domain

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -380,6 +380,18 @@ function valid_ip()
     return $stat
 }
 
+#Call this function to use a regex to check user input for a valid custom domain
+function valid_domain()
+{
+  local domain=$1
+  local stat=1
+
+  if [[ $domain =~ ^[a-zA-Z0-9][a-zA-Z0-9-]{1,61}\.[a-zA-Z]{2,}$ ]]; then
+    stat=$?
+  fi
+  return $stat
+}
+
 installScripts() {
     # Install the scripts from /etc/.pivpn to their various locations
     $SUDO echo ":::"

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -727,7 +727,7 @@ setCustomDomain() {
             if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Are these settings correct?\n    Custom Search Domain: $CUSTOMDomain" ${r} ${c}); then
                 DomainSettingsCorrect=True
 
-                $SUDO sed -i '0,/\(.*dhcp-option.*\)/s//\push "dhcp-option DOMAIN '${CUSTOMDomain}'" /' server.conf
+                $SUDO sed -i '0,/\(.*dhcp-option.*\)/s//\push "dhcp-option DOMAIN '${CUSTOMDomain}'" /' /etc/openvpn/server.conf
 
             else
                 # If the settings are wrong, the loop continues

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -727,7 +727,7 @@ setCustomDomain() {
             if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Are these settings correct?\n    Custom Search Domain: $CUSTOMDomain" ${r} ${c}); then
                 DomainSettingsCorrect=True
 
-                $SUDO sed -i '0,/\(.*dhcp-option.*\)/s//\push "dhcp-option DOMAIN '${CUSTOMDomain}'" /' /etc/openvpn/server.conf
+                $SUDO sed -i '0,/\(.*dhcp-option.*\)/s//\push "dhcp-option DOMAIN '${CUSTOMDomain}'" \n&/' /etc/openvpn/server.conf
 
             else
                 # If the settings are wrong, the loop continues

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -722,16 +722,20 @@ setCustomDomain() {
 
     until [[ $DomainSettingsCorrect = True ]]
     do
-      if CUSTOMDomain=$(whiptail --inputbox "Enter Custom Domain\nFormat: mydomain.com" 8 78 --title "Test" 3>&1 1>&2 2>&3); then
+      if CUSTOMDomain=$(whiptail --inputbox "Enter Custom Domain\nFormat: mydomain.com" 8 78 --title "Custom Domain" 3>&1 1>&2 2>&3); then
+          if valid_domain "$CUSTOMDomain"; then
+            if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Are these settings correct?\n    Custom Search Domain: $CUSTOMDomain" 8 78); then
+                DomainSettingsCorrect=True
 
-          if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Are these settings correct?\n    Custom Search Domain: $CUSTOMDomain" 8 78); then
-              DomainSettingsCorrect=True
+                $SUDO sed -i '0,/\(.*dhcp-option.*\)/s//\push "dhcp-option DOMAIN '${CUSTOMDomain}'" /' server.conf
 
-              $SUDO sed -i '0,/\(.*dhcp-option.*\)/s//\push "dhcp-option DOMAIN '${CUSTOMDomain}'" /' /etc/openvpn/server.conf
-
+            else
+                # If the settings are wrong, the loop continues
+                DomainSettingsCorrect=False
+            fi
           else
-              # If the settings are wrong, the loop continues
-              DomainSettingsCorrect=False
+            whiptail --msgbox --backtitle "Invalid Domain" --title "Invalid Domain" "Domain is invalid. Please try again.\n\n    DOMAIN:   $CUSTOMDomain\n" 8 78
+            DomainSettingsCorrect=False
           fi
       else
         echo "::: Cancel selected. Exiting..."

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -718,13 +718,13 @@ setClientDNS() {
 setCustomDomain() {
   DomainSettingsCorrect=False
 
-  if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Would you like to add a custom search domain? \n (This is only for advanced users who have their own domain)\n" 8 78); then
+  if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Would you like to add a custom search domain? \n (This is only for advanced users who have their own domain)\n" ${r} ${c}); then
 
     until [[ $DomainSettingsCorrect = True ]]
     do
-      if CUSTOMDomain=$(whiptail --inputbox "Enter Custom Domain\nFormat: mydomain.com" 8 78 --title "Custom Domain" 3>&1 1>&2 2>&3); then
+      if CUSTOMDomain=$(whiptail --inputbox "Enter Custom Domain\nFormat: mydomain.com" ${r} ${c} --title "Custom Domain" 3>&1 1>&2 2>&3); then
           if valid_domain "$CUSTOMDomain"; then
-            if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Are these settings correct?\n    Custom Search Domain: $CUSTOMDomain" 8 78); then
+            if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Are these settings correct?\n    Custom Search Domain: $CUSTOMDomain" ${r} ${c}); then
                 DomainSettingsCorrect=True
 
                 $SUDO sed -i '0,/\(.*dhcp-option.*\)/s//\push "dhcp-option DOMAIN '${CUSTOMDomain}'" /' server.conf
@@ -734,7 +734,7 @@ setCustomDomain() {
                 DomainSettingsCorrect=False
             fi
           else
-            whiptail --msgbox --backtitle "Invalid Domain" --title "Invalid Domain" "Domain is invalid. Please try again.\n\n    DOMAIN:   $CUSTOMDomain\n" 8 78
+            whiptail --msgbox --backtitle "Invalid Domain" --title "Invalid Domain" "Domain is invalid. Please try again.\n\n    DOMAIN:   $CUSTOMDomain\n" ${r} ${c}
             DomainSettingsCorrect=False
           fi
       else

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -715,7 +715,7 @@ setCustomDomain() {
           if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Are these settings correct?\n    Custom Search Domain: $CUSTOMDomain" 8 78); then
               DomainSettingsCorrect=True
 
-              $SUDO sed -i '0,/\(.*dhcp-option.*\)/s//\push "dhcp-option DOMAIN '${CUSTOMDomain}'" /' server.conf
+              $SUDO sed -i '0,/\(.*dhcp-option.*\)/s//\push "dhcp-option DOMAIN '${CUSTOMDomain}'" /' /etc/openvpn/server.conf
 
           else
               # If the settings are wrong, the loop continues

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -10,6 +10,8 @@
 # curl -L https://install.pivpn.io | bash
 # Make sure you have `curl` installed
 
+#Adding custom search domain - atlasalex
+
 set -e
 ######## VARIABLES #########
 
@@ -32,7 +34,7 @@ pivpnFilesDir="/etc/.pivpn"
 easyrsaVer="3.0.4"
 easyrsaRel="https://github.com/OpenVPN/easy-rsa/releases/download/v${easyrsaVer}/EasyRSA-${easyrsaVer}.tgz"
 
-# Raspbian's unattended-upgrades package downloads Debian's config, so this is the link for the proper config 
+# Raspbian's unattended-upgrades package downloads Debian's config, so this is the link for the proper config
 UNATTUPG_CONFIG="https://github.com/mvo5/unattended-upgrades/archive/1.4.tar.gz"
 
 # Find the rows and columns. Will default to 80x24 if it can not be detected.


### PR DESCRIPTION
Main changes:

  This code creates a new setCustomDomain() procedure to allow users the option to add a custom search domain during install.

It also adds a function valid_domain() that uses regex to do a mild validation on domain input.

This code will then insert into the created server.conf