### PR TITLE
Update easy-rsa version

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -29,7 +29,7 @@ PIVPN_DEPS=(openvpn git tar wget grep iptables-persistent dnsutils expect whipta
 
 pivpnGitUrl="https://github.com/pivpn/pivpn.git"
 pivpnFilesDir="/etc/.pivpn"
-easyrsaVer="3.0.4"
+easyrsaVer="3.0.6"
 easyrsaRel="https://github.com/OpenVPN/easy-rsa/releases/download/v${easyrsaVer}/EasyRSA-${easyrsaVer}.tgz"
 
 # Raspbian's unattended-upgrades package downloads Debian's config, so this is the link for the proper config 


### PR DESCRIPTION
Update easy-rsa version to v3.0.6, which would allow for us to implement a certificate renewal option, since easy-rsa now supports certificate renewal (https://github.com/OpenVPN/easy-rsa/pull/286)!