### PR TITLE
Fixed rsyslog deprecated discard from ~ to stop

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1021,7 +1021,7 @@ confOVPN() {
 
 confLogging() {
   echo "if \$programname == 'ovpn-server' then /var/log/openvpn.log
-if \$programname == 'ovpn-server' then ~" | $SUDO tee /etc/rsyslog.d/30-openvpn.conf > /dev/null
+if \$programname == 'ovpn-server' then stop" | $SUDO tee /etc/rsyslog.d/30-openvpn.conf > /dev/null
 
   echo "/var/log/openvpn.log
 {


### PR DESCRIPTION
This pull request fixed rsyslog deprecation warning found in `/var/log/syslog`.

In one of my machine, `sudo service rsyslog restart` failed to create `/var/log/openvpn.log`.

However, this was fixed upon incorporating the change made in this pull request.

https://www.rsyslog.com/doc/v8-stable/compatibility/v7compatibility.html#omruleset-and-discard-action-are-deprecated

According to the link above:

> omruleset and discard (~) action are deprecated
>
> Both continue to work, but have been replaced by better alternatives.
>
> The discard action (tilde character) has been replaced by the “stop” RainerScript directive. It is considered more intuitive and offers slightly better performance.
> 
> The omruleset module has been replaced by the “call” RainerScript directive. Call permits to execute a ruleset like a subroutine, and does so with much higher performance than omruleset did. Note that omruleset could be run off an async queue. This was more a side than a desired effect and is not supported by the call statement. If that effect was needed, it can simply be simulated by running the called rulesets actions asynchronously (what in any case is the right way to handle this).
>
> Note that the deprecated modules emit warning messages when being used. They tell that the construct is deprecated and which statement is to be used as replacement. This does not affect operations: both modules are still fully operational and will not be removed in the v7 timeframe.