### PR TITLE
Always set tls-crypt instead of tls-auth

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -841,11 +841,6 @@ EOF
     $SUDO cp /etc/.pivpn/server_config.txt /etc/openvpn/server.conf
 
     if [[ ${APPLY_TWO_POINT_FOUR} == true ]]; then
-      #If they enabled 2.4 use tls-crypt instead of tls-auth to encrypt control channel
-      $SUDO sed -i "s/tls-auth \/etc\/openvpn\/easy-rsa\/pki\/ta.key 0/tls-crypt \/etc\/openvpn\/easy-rsa\/pki\/ta.key/" /etc/openvpn/server.conf
-    fi
-
-    if [[ ${APPLY_TWO_POINT_FOUR} == true ]]; then
       #If they enabled 2.4 disable dh parameters since the key exchange will use the matching curve from the ECDSA certificate
       $SUDO sed -i "s/\(dh \/etc\/openvpn\/easy-rsa\/pki\/dh\).*/dh none/" /etc/openvpn/server.conf
     else

--- a/server_config.txt
+++ b/server_config.txt
@@ -20,7 +20,7 @@ client-to-client
 keepalive 1800 3600
 remote-cert-tls client
 tls-version-min 1.2
-tls-auth /etc/openvpn/easy-rsa/pki/ta.key 0
+tls-crypt /etc/openvpn/easy-rsa/pki/ta.key
 cipher AES-256-CBC
 auth SHA256
 user nobody


### PR DESCRIPTION
The install script always installs OpenVPN 2.4, even if it has to
install it from a third-party repository. In 2.4, tls-auth has been
replaced by tls-crypt and tls-crypt must be specified even if using
traditional RSA cryptography.

In short, RSA is currently broken and this patch is necessary to make it work again.