### PR TITLE
Flush disk writes before reboot

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,7 +1,5 @@
 <!-- PLEASE READ THIS TEMPLATE CAREFULLY BEFORE OPENING AN ISSUE! -->
 
-PiVPN is no longer maintained, see the README
-
 <!-- Hi, you are about to open a new issue, Please provide us with all the info required below, incomplete issues will decrease our effectiveness to troubleshoot your issue and increase the time we need to spend helping you out, or with your issue closed even if it is a legitimate issue. Please remember we do not have any super power that makes us guess exactly what your issue is without any decent details! -->
 
 <!-- For any output requested below, you may alternatively post it on http://pastebin.com and provide the Pastebin URL in its place -->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+0-kaladin:  Sad times.  I love this project just have no time to properly give it the attention it deserves.  I'm still around so if anyone is willing to pick this up and keep it running just create an issue to let me know.  Thanks to all who've kept this going as current life changes don't allow time for hobbies.  Hopefully in the future... I wanted to get this to <pip install pivpn> at one point.
+
+
 PiVPN is no longer maintained
 ============
 
@@ -14,7 +17,6 @@ and people who provided support in the issues.
 
 -- redfast00
 
-0-kaladin:  Sad times.  I love this project just have no time to properly give it the attention it deserves.  I'm still around so if anyone is willing to pick this up and keep it running just create an issue to let me know.  Thanks to all who've kept this going as current life changes don't allow time for hobbies.  Hopefully in the future... I wanted to get this to <pip install pivpn> at one point.
 
 About
 -----

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and people who provided support in the issues.
 
 -- redfast00
 
-
+0-kaladin:  Sad times.  I love this project just have no time to properly give it the attention it deserves.  I'm still around so if anyone is willing to pick this up and keep it running just create an issue to let me know.  Thanks to all who've kept this going as current life changes don't allow time for hobbies.  Hopefully in the future... I wanted to get this to <pip install pivpn> at one point.
 
 About
 -----

--- a/README.md
+++ b/README.md
@@ -1,22 +1,12 @@
-0-kaladin:  Sad times.  I love this project just have no time to properly give it the attention it deserves.  I'm still around so if anyone is willing to pick this up and keep it running just create an issue to let me know.  Thanks to all who've kept this going as current life changes don't allow time for hobbies.  Hopefully in the future... I wanted to get this to <pip install pivpn> at one point.
-
-
-PiVPN is no longer maintained
+PiVPN is once again maintained
 ============
 
-I'm stepping down as pivpn maintainer, since it would take too much of my time to maintain it
-properly. @0-kaladin (the owner of the pivpn organisation) didn't give anyone owner rights on the organisation, so I'm not able to add new people as member.
+james-lasersoft: 0-kaladin has assigned me as new admin for this project. I will do my best to keep things rolling into the future. I would like to thanks 0-kaladin for creating the most excellent project and I would also like to thank all of the future contributions we will receive from our zealous followers as they keep me on track.
 
-This means that there are no longer any active maintainers for this project, and that issues and PR's will not get resolved. This will eventually result in pivpn not working anymore (as openvpn gets updates, config options might get added/removed/changed).
 
-Now, what can you if you want to keep pivpn alive? Not much really, but you can fork it and ma
-ke your own "pivpn" (please don't call it that to avoid confusion). If you do use our code, please don't forget to mention that in a README or something (our MIT licence requires that).
+-----
 
-I'd like to thank @0-kaladin and @cfcolaco for working on this with me, and all contributors
-and people who provided support in the issues.   
-
--- redfast00
-
+0-kaladin:  Sad times.  I love this project just have no time to properly give it the attention it deserves.  I'm still around so if anyone is willing to pick this up and keep it running just create an issue to let me know.  Thanks to all who've kept this going as current life changes don't allow time for hobbies.  Hopefully in the future... I wanted to get this to <pip install pivpn> at one point.
 
 About
 -----

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1331,6 +1331,10 @@ main() {
             $SUDO systemctl start openvpn.service
             ;;
     esac
+    
+    # Ensure that cached writes reach persistent storage
+    echo "::: Flushing writes to disk..."
+    sync
 
     echo "::: done."
 


### PR DESCRIPTION
Background: I installed PiVPN today for the first time. After allowing this script to reboot my Pi at the end of installation, many of the script's install products were missing (including `/etc/openvpn/easy-rsa/pki/Default.txt` and `/etc/pivpn/INSTALL_USER`). PiVPN struggled along and seemed like it was working, but generated corrupt .ovpn files so I could not set up my client. The install log (which unfortunately got lost after I reinstalled!) did not indicate an error.

I hypothesize (admittedly with very little evidence) that the reboot clobbered some pending writes before they were flushed to my Pi's very very slow SD card.

This commit introduces a `sync` call before the install script exits, which should increase the chance that the writes done during the install survive reboot.