### PR TITLE
Custom certificate duration and more flexible names

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -405,7 +405,6 @@ installScripts() {
     $SUDO cp /etc/.pivpn/scripts/removeOVPN.sh /opt/pivpn/removeOVPN.sh
     $SUDO cp /etc/.pivpn/scripts/uninstall.sh /opt/pivpn/uninstall.sh
     $SUDO cp /etc/.pivpn/scripts/pivpnDebug.sh /opt/pivpn/pivpnDebug.sh
-    $SUDO cp /etc/.pivpn/scripts/fix_iptables.sh /opt/pivpn/fix_iptables.sh
     $SUDO chmod 0755 /opt/pivpn/{makeOVPN,clientStat,listOVPN,removeOVPN,uninstall,pivpnDebug,fix_iptables}.sh
     $SUDO cp /etc/.pivpn/pivpn /usr/local/bin/pivpn
     $SUDO chmod 0755 /usr/local/bin/pivpn

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -405,7 +405,7 @@ installScripts() {
     $SUDO cp /etc/.pivpn/scripts/removeOVPN.sh /opt/pivpn/removeOVPN.sh
     $SUDO cp /etc/.pivpn/scripts/uninstall.sh /opt/pivpn/uninstall.sh
     $SUDO cp /etc/.pivpn/scripts/pivpnDebug.sh /opt/pivpn/pivpnDebug.sh
-    $SUDO chmod 0755 /opt/pivpn/{makeOVPN,clientStat,listOVPN,removeOVPN,uninstall,pivpnDebug,fix_iptables}.sh
+    $SUDO chmod 0755 /opt/pivpn/{makeOVPN,clientStat,listOVPN,removeOVPN,uninstall,pivpnDebug}.sh
     $SUDO cp /etc/.pivpn/pivpn /usr/local/bin/pivpn
     $SUDO chmod 0755 /usr/local/bin/pivpn
     $SUDO cp /etc/.pivpn/scripts/bash-completion /etc/bash_completion.d/pivpn

--- a/scripts/makeOVPN.sh
+++ b/scripts/makeOVPN.sh
@@ -185,10 +185,13 @@ fi
 #As of EasyRSA 3.0.6, by default certificates last 1080 days, see https://github.com/OpenVPN/easy-rsa/blob/6b7b6bf1f0d3c9362b5618ad18c66677351cacd1/easyrsa3/vars.example
 if [ -z "${DAYS}" ]; then
     read -r -e -p "How many days should the certificate last?  " -i 1080 DAYS
-elif [[ ! "$DAYS" =~ ^[0-9]+$ ]] || [ "$DAYS" -lt 1 ] || [ "$DAYS" -gt 3650 ]; then
+fi
+
+if [[ ! "$DAYS" =~ ^[0-9]+$ ]] || [ "$DAYS" -lt 1 ] || [ "$DAYS" -gt 3650 ]; then
     #The CRL lasts 3650 days so it doesn't make much sense that certificates would last longer
     echo "Please input a valid number of days, between 1 and 3650 inclusive."
     exit 1
+
 fi
 
 cd /etc/openvpn/easy-rsa || exit

--- a/scripts/makeOVPN.sh
+++ b/scripts/makeOVPN.sh
@@ -13,11 +13,12 @@ INSTALL_USER=$(cat /etc/pivpn/INSTALL_USER)
 helpFunc() {
     echo "::: Create a client ovpn profile, optional nopass"
     echo ":::"
-    echo "::: Usage: pivpn <-a|add> [-n|--name <arg>] [-p|--password <arg>]|[nopass] [-h|--help]"
+    echo "::: Usage: pivpn <-a|add> [-n|--name <arg>] [-p|--password <arg>]|[nopass] [-d|--days <number>] [-h|--help]"
     echo ":::"
     echo "::: Commands:"
     echo ":::  [none]               Interactive mode"
     echo ":::  nopass               Create a client without a password"
+    echo ":::  -d,--days            Expire the certificate after specified number of days (default: 1080)"
     echo ":::  -n,--name            Name for the Client (default: '"$(hostname)"')"
     echo ":::  -p,--password        Password for the Client (no default)"
     echo ":::  -h,--help            Show this help dialog"
@@ -48,6 +49,16 @@ do
             fi
             PASSWD="$_val"
             ;;
+        -d|--days|--days=*)
+            _val="${_key##--days=}"
+            if test "$_val" = "$_key"
+            then
+                test $# -lt 2 && echo "Missing value for the optional argument '$_key'." && exit 1
+                _val="$2"
+                shift
+            fi
+            DAYS="$_val"
+            ;;
         -h|--help)
             helpFunc
             exit 0
@@ -71,6 +82,7 @@ function keynoPASS() {
     #Build the client key
     expect << EOF
     set timeout -1
+    set env(EASYRSA_CERT_EXPIRE) "${DAYS}"
     spawn ./easyrsa build-client-full "${NAME}" nopass
     expect eof
 EOF
@@ -115,6 +127,7 @@ function keyPASS() {
 
     expect << EOF
     set timeout -1
+    set env(EASYRSA_CERT_EXPIRE) "${DAYS}"
     spawn ./easyrsa build-client-full "${NAME}"
     expect "Enter PEM pass phrase" { send -- "${PASSWD}\r" }
     expect "Verifying - Enter PEM pass phrase" { send -- "${PASSWD}\r" }
@@ -129,8 +142,13 @@ if [ -z "${NAME}" ]; then
     read -r NAME
 fi
 
-if [[ "${NAME}" =~ [^a-zA-Z0-9\-] ]]; then
-    echo "Name can only contain alphanumeric characters and dashes (-)."
+if [[ ${NAME::1} == "." ]] || [[ ${NAME::1} == "-" ]]; then
+    echo "Names cannot start with a dot (.) or a dash (-)."
+    exit 1
+fi
+
+if [[ "${NAME}" =~ [^a-zA-Z0-9\.\-\@\_] ]]; then
+    echo "Name can only contain alphanumeric characters and these characters (.-@_)."
     exit 1
 fi
 
@@ -161,6 +179,15 @@ fi
 # Check if name is reserved
 if [ "${NAME}" == "ta" ] || [ "${NAME}" == "server" ] || [ "${NAME}" == "ca" ]; then
     echo "Sorry, this is in use by the server and cannot be used by clients."
+    exit 1
+fi
+
+#As of EasyRSA 3.0.6, by default certificates last 1080 days, see https://github.com/OpenVPN/easy-rsa/blob/6b7b6bf1f0d3c9362b5618ad18c66677351cacd1/easyrsa3/vars.example
+if [ -z "${DAYS}" ]; then
+    read -r -e -p "How many days should the certificate last?  " -i 1080 DAYS
+elif [[ ! "$DAYS" =~ ^[0-9]+$ ]] || [ "$DAYS" -lt 1 ] || [ "$DAYS" -gt 3650 ]; then
+    #The CRL lasts 3650 days so it doesn't make much sense that certificates would last longer
+    echo "Please input a valid number of days, between 1 and 3650 inclusive."
     exit 1
 fi
 


### PR DESCRIPTION
As per request on issue #530 I added the ability to make client certificates last a custom number of days. 
I also relaxed the check for characters in the username as suggested in #696.
@Giraffe1966 pointed out that clients starting with dot would be hidden, so I chose just not to allow them.
Similarly, names starting with dash should also not be allowed since they would be interpreted as command line arguments when provided via... command line argument.