### PR TITLE
ensure -n checks returned value

### DIFF
--- a/scripts/clientStat.sh
+++ b/scripts/clientStat.sh
@@ -20,7 +20,7 @@ printf "\e[1m::: Client Status List :::\e[0m\n"
 printf "\t\t\t\t\t\t\t\tBytes\t\tBytes\t\n"
 printf "\e[4mName\e[0m\t\t\t\e[4mRemote IP\e[0m\t\t\e[4mVirtual IP\e[0m\t\e[4mReceived\e[0m\t\e[4mSent\e[0m\t\t\e[4mConnected Since\e[0m \n"
 if grep -q "^CLIENT_LIST" "${STATUS_LOG}"; then
-        if [ -n $(type -t numfmt) ]; then
+        if [ -n "$(type -t numfmt)" ]; then
                 while read -r line; do
                         read -r -a array <<< $line
                         [[ ${array[0]} = CLIENT_LIST ]] || continue


### PR DESCRIPTION
Running [shellcheck](https://github.com/koalaman/shellcheck):

```
shellcheck clientStat.sh

In clientStat.sh line 23:
        if [ -n $(type -t numfmt) ]; then
                ^---------------^ SC2070: -n doesn't work with unquoted arguments. Quote or use [[ ]].
```

This PR fixes the issue [SC2070](https://github.com/koalaman/shellcheck/wiki/SC2070)