### PR TITLE
Leverage the Hostname of the Server

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -763,8 +763,8 @@ confOpenVPN() {
     # Grab the existing Hostname
 	HOST_NAME=$(hostname -s)
 	# Generate a random UUID for this server so that we can use verify-x509-name later that is unique for this server installation.
-    $NEW_UUID=$(</proc/sys/kernel/random/uuid)
-    # Create a unique server name using the host name and UUID
+    	NEW_UUID=$(</proc/sys/kernel/random/uuid)
+   	# Create a unique server name using the host name and UUID
 	SERVER_NAME="${HOST_NAME}_${NEW_UUID}"
 
     declare -A ECDSA_MAP=(["256"]="prime256v1" ["384"]="secp384r1" ["521"]="secp521r1")

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -746,7 +746,7 @@ setCustomDomain() {
 
 confOpenVPN() {
     # Grab the existing Hostname
-	HOST_NAME=$(hostname)
+	HOST_NAME=$(hostname -s)
 	# Generate a random, alphanumeric identifier of 16 characters for this server so that we can use verify-x509-name later that is unique for this server installation. Source: Earthgecko (https://gist.github.com/earthgecko/3089509)
     NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
     # Create a unique server name using the host name and UUID

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -21,7 +21,7 @@ PKG_CACHE="/var/lib/apt/lists/"
 UPDATE_PKG_CACHE="${PKG_MANAGER} update"
 PKG_INSTALL="${PKG_MANAGER} --yes --no-install-recommends install"
 PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
-PIVPN_DEPS=(openvpn git tar wget grep iptables-persistent dnsutils expect whiptail net-tools grepcidr jq uuidgen)
+PIVPN_DEPS=(openvpn git tar wget grep iptables-persistent dnsutils expect whiptail net-tools grepcidr jq)
 
 ###          ###
 
@@ -763,7 +763,7 @@ confOpenVPN() {
     # Grab the existing Hostname
 	HOST_NAME=$(hostname -s)
 	# Generate a random UUID for this server so that we can use verify-x509-name later that is unique for this server installation.
-    NEW_UUID=$uuidgen -r
+    $NEW_UUID=$(</proc/sys/kernel/random/uuid)
     # Create a unique server name using the host name and UUID
 	SERVER_NAME="${HOST_NAME}_${NEW_UUID}"
 

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -747,8 +747,8 @@ setCustomDomain() {
 confOpenVPN() {
     # Grab the existing Hostname
 	HOST_NAME=$(hostname -s)
-	# Generate a random, alphanumeric identifier of 16 characters for this server so that we can use verify-x509-name later that is unique for this server installation. Source: Earthgecko (https://gist.github.com/earthgecko/3089509)
-    NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+	# Generate a random UUID for this server so that we can use verify-x509-name later that is unique for this server installation.
+    NEW_UUID=$uuidgen -r
     # Create a unique server name using the host name and UUID
 	SERVER_NAME="${HOST_NAME}_${NEW_UUID}"
 

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -745,9 +745,12 @@ setCustomDomain() {
 }
 
 confOpenVPN() {
-    # Generate a random, alphanumeric identifier of 16 characters for this server so that we can use verify-x509-name later that is unique for this server installation. Source: Earthgecko (https://gist.github.com/earthgecko/3089509)
+    # Grab the existing Hostname
+	HOST_NAME=$(hostname)
+	# Generate a random, alphanumeric identifier of 16 characters for this server so that we can use verify-x509-name later that is unique for this server installation. Source: Earthgecko (https://gist.github.com/earthgecko/3089509)
     NEW_UUID=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
-    SERVER_NAME="server_${NEW_UUID}"
+    # Create a unique server name using the host name and UUID
+	SERVER_NAME="${HOST_NAME}_${NEW_UUID}"
 
     if [[ ${useUpdateVars} == false ]]; then
         # Ask user for desired level of encryption

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -21,7 +21,7 @@ PKG_CACHE="/var/lib/apt/lists/"
 UPDATE_PKG_CACHE="${PKG_MANAGER} update"
 PKG_INSTALL="${PKG_MANAGER} --yes --no-install-recommends install"
 PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
-PIVPN_DEPS=(openvpn git tar wget grep iptables-persistent dnsutils expect whiptail net-tools)
+PIVPN_DEPS=(openvpn git tar wget grep iptables-persistent dnsutils expect whiptail net-tools uuidgen)
 ###          ###
 
 pivpnGitUrl="https://github.com/pivpn/pivpn.git"


### PR DESCRIPTION
Historic versions leveraged a format of "server_$UUID" to name of the VPN server certificate for X509 verification.  This seems very impersonal.  The new code pulls the existing hostname of the machines and appends the 16 character UUID.  The new format is $hostname_$UUID.

Example:
A machine named "Martian" with a UUID of 1234567890123456 would change from server_1234567890123456 to Martian_1234567890123456