### PR TITLE
Hide client IPs inside the debug log

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -21,7 +21,7 @@ PKG_CACHE="/var/lib/apt/lists/"
 UPDATE_PKG_CACHE="${PKG_MANAGER} update"
 PKG_INSTALL="${PKG_MANAGER} --yes --no-install-recommends install"
 PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
-PIVPN_DEPS=(openvpn git tar wget grep iptables-persistent dnsutils expect whiptail net-tools)
+PIVPN_DEPS=(openvpn git tar wget grep iptables-persistent dnsutils expect whiptail net-tools grepcidr)
 ###          ###
 
 pivpnGitUrl="https://github.com/pivpn/pivpn.git"

--- a/scripts/pivpnDebug.sh
+++ b/scripts/pivpnDebug.sh
@@ -13,8 +13,9 @@ echo -e "::::\t\t\e[4mLatest commit\e[0m\t\t ::::"
 git --git-dir /etc/.pivpn/.git log -n 1
 printf "=============================================\n"
 echo -e "::::\t    \e[4mInstallation settings\e[0m    \t ::::"
+# Use the wildcard so setupVars.conf.update.bak from the previous install is not shown
 for filename in /etc/pivpn/*; do
-    if [ "$filename" != "/etc/pivpn/setupVars.conf" ]; then
+    if [[ "$filename" != "/etc/pivpn/setupVars.conf"* ]]; then
         echo "$filename -> $(cat "$filename")"
     fi
 done
@@ -151,7 +152,17 @@ fi
 
 printf "=============================================\n"
 echo -e "::::      \e[4mSnippet of the server log\e[0m      ::::"
-tail -20 /var/log/openvpn.log
+tail -20 /var/log/openvpn.log > /tmp/snippet
+
+# Regular expession taken from https://superuser.com/a/202835, it will match invalid IPs
+# like 123.456.789.012 but it's fine because the log only contains valid ones.
+declare -a IPS_TO_HIDE=($(grepcidr -v 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 /tmp/snippet | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | uniq))
+for IP in "${IPS_TO_HIDE[@]}"; do
+    sed -i "s/$IP/REDACTED/g" /tmp/snippet
+done
+
+cat /tmp/snippet
+rm /tmp/snippet
 printf "=============================================\n"
 echo -e "::::\t\t\e[4mDebug complete\e[0m\t\t ::::"
 


### PR DESCRIPTION
This pull requests redacts all public IP addresses inside the snippet of the server log, which are usually client IPs. It does such by using grepcidr to select lines with non private IP ranges, uses grep and uniq to extract the individual IPs and sed to replace them.