### PR TITLE
Improve iptables detection

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,21 +1,6 @@
 #!/usr/bin/env bash
 # PiVPN: Uninstall Script
 
-# Must be root to uninstall
-if [[ $EUID -eq 0 ]];then
-    echo "::: You are root."
-else
-    echo "::: Sudo will be used for the uninstall."
-  # Check if it is actually installed
-  # If it isn't, exit because the unnstall cannot complete
-  if [[ $(dpkg-query -s sudo) ]];then
-        export SUDO="sudo"
-  else
-    echo "::: Please install sudo or run this as root."
-    exit 1
-  fi
-fi
-
 INSTALL_USER=$(cat /etc/pivpn/INSTALL_USER)
 PLAT=$(cat /etc/pivpn/DET_PLATFORM)
 NO_UFW=$(cat /etc/pivpn/NO_UFW)
@@ -59,7 +44,7 @@ echo ":::"
             while true; do
                 read -rp "::: Do you wish to remove $i from your system? [y/n]: " yn
                 case $yn in
-                    [Yy]* ) printf ":::\tRemoving %s..." "$i"; $SUDO apt-get -y remove --purge "$i" &> /dev/null & spinner $!; printf "done!\n";
+                    [Yy]* ) printf ":::\tRemoving %s..." "$i"; apt-get -y remove --purge "$i" &> /dev/null & spinner $!; printf "done!\n";
                             if [ "$i" == "openvpn" ]; then UINST_OVPN=1 ; fi
                             if [ "$i" == "unattended-upgrades" ]; then UINST_UNATTUPG=1 ; fi
                             break;;
@@ -74,44 +59,57 @@ echo ":::"
 
     # Take care of any additional package cleaning
     printf "::: Auto removing remaining dependencies..."
-    $SUDO apt-get -y autoremove &> /dev/null & spinner $!; printf "done!\n";
+    apt-get -y autoremove &> /dev/null & spinner $!; printf "done!\n";
     printf "::: Auto cleaning remaining dependencies..."
-    $SUDO apt-get -y autoclean &> /dev/null & spinner $!; printf "done!\n";
+    apt-get -y autoclean &> /dev/null & spinner $!; printf "done!\n";
 
     echo ":::"
     # Removing pivpn files
     echo "::: Removing pivpn system files..."
-    $SUDO rm -rf /opt/pivpn &> /dev/null
-    $SUDO rm -rf /etc/.pivpn &> /dev/null
-    $SUDO rm -rf /home/$INSTALL_USER/ovpns &> /dev/null
+    rm -rf /opt/pivpn &> /dev/null
+    rm -rf /etc/.pivpn &> /dev/null
+    rm -rf /home/$INSTALL_USER/ovpns &> /dev/null
 
-    $SUDO rm -rf /var/log/*pivpn* &> /dev/null
-    $SUDO rm -rf /var/log/*openvpn* &> /dev/null
+    rm -rf /var/log/*pivpn* &> /dev/null
+    rm -rf /var/log/*openvpn* &> /dev/null
     if [[ $UINST_OVPN = 1 ]]; then
-        $SUDO rm -rf /etc/openvpn &> /dev/null
+        rm -rf /etc/openvpn &> /dev/null
         if [[ $PLAT == "Ubuntu" || $PLAT == "Debian" ]]; then
             printf "::: Removing openvpn apt source..."
-            $SUDO rm -rf /etc/apt/sources.list.d/swupdate.openvpn.net.list &> /dev/null
-            $SUDO apt-get -qq update & spinner $!; printf "done!\n";
+            rm -rf /etc/apt/sources.list.d/swupdate.openvpn.net.list &> /dev/null
+            apt-get -qq update & spinner $!; printf "done!\n";
         fi
     fi
     if [[ $UINST_UNATTUPG = 1 ]]; then
-        $SUDO rm -rf /var/log/unattended-upgrades
-        $SUDO rm -rf /etc/apt/apt.conf.d/*periodic
+        rm -rf /var/log/unattended-upgrades
+        rm -rf /etc/apt/apt.conf.d/*periodic
     fi
-    $SUDO rm -rf /etc/pivpn &> /dev/null
-    $SUDO rm /usr/local/bin/pivpn &> /dev/null
-    $SUDO rm /etc/bash_completion.d/pivpn
+    rm -rf /etc/pivpn &> /dev/null
+    rm /usr/local/bin/pivpn &> /dev/null
+    rm /etc/bash_completion.d/pivpn
 
     # Disable IPv4 forwarding
     sed -i '/net.ipv4.ip_forward=1/c\#net.ipv4.ip_forward=1' /etc/sysctl.conf
     sysctl -p
 
     if [[ $NO_UFW -eq 0 ]]; then
-        $SUDO sed -z "s/*nat\n:POSTROUTING ACCEPT \[0:0\]\n-I POSTROUTING -s 10.8.0.0\/24 -o $IPv4dev -j MASQUERADE\nCOMMIT\n\n//" -i /etc/ufw/before.rules
-        $SUDO ufw delete allow "$PORT"/"$PROTO" >/dev/null
-        $SUDO ufw route delete allow in on tun0 from 10.8.0.0/24 out on "$IPv4dev" to any >/dev/null
-        $SUDO ufw reload >/dev/null
+        sed -z "s/*nat\n:POSTROUTING ACCEPT \[0:0\]\n-I POSTROUTING -s 10.8.0.0\/24 -o $IPv4dev -j MASQUERADE\nCOMMIT\n\n//" -i /etc/ufw/before.rules
+        ufw delete allow "$PORT"/"$PROTO" >/dev/null
+        ufw route delete allow in on tun0 from 10.8.0.0/24 out on "$IPv4dev" to any >/dev/null
+        ufw reload >/dev/null
+    else
+        iptables -t nat -D POSTROUTING -s 10.8.0.0/24 -o "${IPv4dev}" -j MASQUERADE
+
+        if [ "$(cat /etc/pivpn/INPUT_CHAIN_EDITED)" -eq 1 ]; then
+            iptables -D INPUT -i "$IPv4dev" -p "$PROTO" --dport "$PORT" -j ACCEPT
+        fi
+
+        if [ "$(cat /etc/pivpn/FORWARD_CHAIN_EDITED)" -eq 1 ]; then
+            iptables -D FORWARD -d 10.8.0.0/24 -i "$IPv4dev" -o tun0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+            iptables -D FORWARD -s 10.8.0.0/24 -i tun0 -o "$IPv4dev" -j ACCEPT
+        fi
+
+        iptables-save > /etc/iptables/rules.v4
     fi
 
     echo ":::"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -7,6 +7,8 @@ NO_UFW=$(cat /etc/pivpn/NO_UFW)
 PORT=$(cat /etc/pivpn/INSTALL_PORT)
 PROTO=$(cat /etc/pivpn/INSTALL_PROTO)
 IPv4dev="$(cat /etc/pivpn/pivpnINTERFACE)"
+INPUT_CHAIN_EDITED="$(cat /etc/pivpn/INPUT_CHAIN_EDITED)"
+FORWARD_CHAIN_EDITED="$(cat /etc/pivpn/FORWARD_CHAIN_EDITED)"
 
 # Find the rows and columns. Will default to 80x24 if it can not be detected.
 screen_size=$(stty size 2>/dev/null || echo 24 80)
@@ -100,11 +102,11 @@ echo ":::"
     else
         iptables -t nat -D POSTROUTING -s 10.8.0.0/24 -o "${IPv4dev}" -j MASQUERADE
 
-        if [ "$(cat /etc/pivpn/INPUT_CHAIN_EDITED)" -eq 1 ]; then
+        if [ "$INPUT_CHAIN_EDITED" -eq 1 ]; then
             iptables -D INPUT -i "$IPv4dev" -p "$PROTO" --dport "$PORT" -j ACCEPT
         fi
 
-        if [ "$(cat /etc/pivpn/FORWARD_CHAIN_EDITED)" -eq 1 ]; then
+        if [ "$FORWARD_CHAIN_EDITED" -eq 1 ]; then
             iptables -D FORWARD -d 10.8.0.0/24 -i "$IPv4dev" -o tun0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
             iptables -D FORWARD -s 10.8.0.0/24 -i tun0 -o "$IPv4dev" -j ACCEPT
         fi


### PR DESCRIPTION
Handle non-default firewall configuration where the user may already have some rules that drop incoming packets or block forwarding, like this one #774.
Also: removed `$SUDO` from the uninstall script since `pivpn` already calls it with sudo.