### PR TITLE
Miscellaneous fixes

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -532,7 +532,7 @@ getGitFiles() {
     echo ":::"
     echo "::: Checking for existing base files..."
     if is_repo "${1}"; then
-        update_repo "${1}"
+        update_repo "${1}" "${2}"
     else
         make_repo "${1}" "${2}"
     fi
@@ -565,6 +565,7 @@ update_repo() {
         # Pull the latest commits
         echo -n ":::     Updating repo in $1..."
         $SUDO rm -rf "${1}"
+        cd /etc
         $SUDO git clone -q --depth 1 --no-single-branch "${2}" "${1}" > /dev/null & spinner $!
         cd "${1}" || exit 1
         if [ -z "${TESTING+x}" ]; then
@@ -851,7 +852,7 @@ EOF
     fi
 
     # Build the server
-    ${SUDOE} ./easyrsa build-server-full ${SERVER_NAME} nopass
+    EASYRSA_CERT_EXPIRE=3650 ${SUDOE} ./easyrsa build-server-full ${SERVER_NAME} nopass
 
     if [[ ${useUpdateVars} == false ]]; then
       if [[ ${APPLY_TWO_POINT_FOUR} == false ]]; then

--- a/scripts/makeOVPN.sh
+++ b/scripts/makeOVPN.sh
@@ -147,7 +147,7 @@ if [[ ${NAME::1} == "." ]] || [[ ${NAME::1} == "-" ]]; then
     exit 1
 fi
 
-if [[ "${NAME}" =~ [^a-zA-Z0-9\.\\-\@\_] ]]; then
+if [[ "${NAME}" =~ [^a-zA-Z0-9.@_-] ]]; then
     echo "Name can only contain alphanumeric characters and these characters (.-@_)."
     exit 1
 fi

--- a/scripts/makeOVPN.sh
+++ b/scripts/makeOVPN.sh
@@ -147,7 +147,7 @@ if [[ ${NAME::1} == "." ]] || [[ ${NAME::1} == "-" ]]; then
     exit 1
 fi
 
-if [[ "${NAME}" =~ [^a-zA-Z0-9\.\-\@\_] ]]; then
+if [[ "${NAME}" =~ [^a-zA-Z0-9\.\\-\@\_] ]]; then
     echo "Name can only contain alphanumeric characters and these characters (.-@_)."
     exit 1
 fi


### PR DESCRIPTION
- Issue a server cert that lasts 3650 days instead of the default 1080, so it won't expire before client certs that last more than 1080 days: https://github.com/pivpn/pivpn/issues/784#issuecomment-508844437
- Actually allow dashes in usernames (@mquirin): https://github.com/pivpn/pivpn/issues/786

- The script called `update_repo` [without the second argument](https://github.com/pivpn/pivpn/blob/8e3a95152412a9d35b67d51bfc80379350815252/auto_install/install.sh#L531), the pivpn git url, making `git clone [...]` fail. Moreover, since `/etc/.pivpn`, the current working directory, is deleted [here](https://github.com/pivpn/pivpn/blob/8e3a95152412a9d35b67d51bfc80379350815252/auto_install/install.sh#L547), git will complain, so we move back to /etc: https://github.com/pivpn/pivpn/issues/787

```
::: Checking for existing base files...
:::    Checking /etc/.pivpn is a repo... OK!
:::     Updating repo in /etc/.pivpn... [/]  fatal: repository '' does not exist
./install.sh: line 565: cd: /etc/.pivpn: No such file or directory
```
- The mapping from ecdsa cert size and curve name is [declared](https://github.com/pivpn/pivpn/blob/8e3a95152412a9d35b67d51bfc80379350815252/auto_install/install.sh#L782) inside [this if statement](https://github.com/pivpn/pivpn/blob/8e3a95152412a9d35b67d51bfc80379350815252/auto_install/install.sh#L752), that is not reached when the user installs pivpn over an existing installation (update option). The result is that EASYRSA_CURVE is undefined. We move the associative array outside the if statement to fix: #640

```
+ echo 'set_var EASYRSA_ALGO       ec'
+ tee -a vars
set_var EASYRSA_ALGO       ec
+ echo 'set_var EASYRSA_CURVE      '
+ tee -a vars
set_var EASYRSA_CURVE
+ ./easyrsa --batch init-pki
+ printf '::: Building CA...\n'
+ ./easyrsa --batch build-ca nopass
::: Building CA...
unknown curve name ()

Easy-RSA error:

Curve  not found. Run openssl ecparam -list_curves to show a
list of supported curves.
```
- Make grep return true when there are no matching iptables rules, to avoid conflicts with `set -e`.