### PR TITLE
Failsafe home dir obtaining

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1131,8 +1131,9 @@ confOVPN() {
     # verify server name to strengthen security
     $SUDO sed -i "s/SRVRNAME/${SERVER_NAME}/" /etc/openvpn/easy-rsa/pki/Default.txt
 
-    INSTALL_HOME=$(cat /etc/passwd | grep "$INSTALL_USER" | cut -d: -f6)
-	if [ ! -d "$INSTALL_HOME/ovpns" ]; then
+    INSTALL_HOME=$(grep -m1 "^${INSTALL_USER}:" /etc/passwd | cut -d: -f6)
+    INSTALL_HOME=${INSTALL_HOME%/} # remove possible trailing slash
+    if [ ! -d "$INSTALL_HOME/ovpns" ]; then
         $SUDO mkdir "$INSTALL_HOME/ovpns"
     fi
     $SUDO chmod 0777 -R "$INSTALL_HOME/ovpns"

--- a/scripts/makeOVPN.sh
+++ b/scripts/makeOVPN.sh
@@ -8,7 +8,7 @@ KEY=".key"
 CA="ca.crt"
 TA="ta.key"
 INDEX="/etc/openvpn/easy-rsa/pki/index.txt"
-INSTALL_USER=$(cat /etc/pivpn/INSTALL_USER)
+INSTALL_USER=$(</etc/pivpn/INSTALL_USER)
 
 helpFunc() {
     echo "::: Create a client ovpn profile, optional nopass"
@@ -403,7 +403,8 @@ if [ $RESPONSE == "y" ] || [ $RESPONSE == "Y" ]; then
   fi
 
 # Copy the .ovpn profile to the home directory for convenient remote access
-INSTALL_HOME=$(cat /etc/passwd | grep "$INSTALL_USER" | cut -d: -f6)
+INSTALL_HOME=$(grep -m1 "^${INSTALL_USER}:" /etc/passwd | cut -d: -f6)
+INSTALL_HOME=${INSTALL_HOME%/} # remove possible trailing slash
 cp "/etc/openvpn/easy-rsa/pki/$NAME$FILEEXT" "$INSTALL_HOME/ovpns/$NAME$FILEEXT"
 chown "$INSTALL_USER" "$INSTALL_HOME/ovpns/$NAME$FILEEXT"
 chmod 640 "/etc/openvpn/easy-rsa/pki/$NAME$FILEEXT"

--- a/scripts/removeOVPN.sh
+++ b/scripts/removeOVPN.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # PiVPN: revoke client script
 
-INSTALL_USER=$(cat /etc/pivpn/INSTALL_USER)
-PLAT=$(cat /etc/pivpn/DET_PLATFORM)
+INSTALL_USER=$(</etc/pivpn/INSTALL_USER)
+PLAT=$(</etc/pivpn/DET_PLATFORM)
 INDEX="/etc/openvpn/easy-rsa/pki/index.txt"
 
 helpFunc() {
@@ -104,7 +104,8 @@ fi
 
 cd /etc/openvpn/easy-rsa || exit
 
-INSTALL_HOME=$(cat /etc/passwd | grep "$INSTALL_USER" | cut -d: -f6)
+INSTALL_HOME=$(grep -m1 "^${INSTALL_USER}:" /etc/passwd | cut -d: -f6)
+INSTALL_HOME=${INSTALL_HOME%/} # remove possible trailing slash
 for (( ii = 0; ii < ${#CERTS_TO_REVOKE[@]}; ii++)); do
     printf "\n::: Revoking certificate '"%s"'.\n" "${CERTS_TO_REVOKE[ii]}"
     ./easyrsa --batch revoke "${CERTS_TO_REVOKE[ii]}"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,7 +2,8 @@
 # PiVPN: Uninstall Script
 
 INSTALL_USER=$(cat /etc/pivpn/INSTALL_USER)
-INSTALL_HOME=$(cat /etc/passwd | grep "$INSTALL_USER" | cut -d: -f6)
+INSTALL_HOME=$(grep -m1 "^${INSTALL_USER}:" /etc/passwd | cut -d: -f6)
+INSTALL_HOME=${INSTALL_HOME%/} # remove possible trailing slash
 PLAT=$(cat /etc/pivpn/DET_PLATFORM)
 NO_UFW=$(cat /etc/pivpn/NO_UFW)
 OLD_UFW=$(cat /etc/pivpn/NO_UFW)


### PR DESCRIPTION
Reference: https://github.com/pivpn/pivpn/pull/809#issuecomment-526927268

+ When estimating `$INSTALL_HOME`, assure grep can only match user names, to avoid possible wrong multi-line value
+ Remove possible trailing slash from `$INSTALL_HOME`, to avoid double slash in "`$INSTALL_HOME/ovpns`"
+ Avoid "`cat <file> | grep <pattern>`", since grep can process files directly
+ Avoid "`VAR=$(cat file)`", since "`VAR=$(<file)`" has the same result without using a slow external command

Signed-off-by: MichaIng <micha@dietpi.com>