### PR TITLE
Fix .ovpn12 file, make pivpn -a options discoverable

### DIFF
--- a/pivpn
+++ b/pivpn
@@ -58,7 +58,6 @@ function helpFunc {
     echo ":::"
     echo "::: Commands:"
     echo ":::  -a, add [nopass]     Create a client ovpn profile, optional nopass"
-    echo ":::  -b,--bitwarden       Create and save a client through Bitwarden"
     echo ":::  -c, clients          List any connected clients to the server"
     echo ":::  -d, debug            Start a debugging session if having trouble"
     echo ":::  -l, list             List all valid and revoked certificates"
@@ -75,7 +74,6 @@ fi
 # Handle redirecting to specific functions based on arguments
 case "$1" in
 "-a" | "add"                ) makeOVPNFunc "$@";;
-"-b" | "bitwarden"          ) makeOVPNFunc "$@";;
 "-c" | "clients"            ) listClientsFunc;;
 "-d" | "debug"              ) debugFunc;;
 "-l" | "list"               ) listOVPNFunc;;

--- a/scripts/makeOVPN.sh
+++ b/scripts/makeOVPN.sh
@@ -15,15 +15,15 @@ INSTALL_HOME=${INSTALL_HOME%/} # remove possible trailing slash
 helpFunc() {
     echo "::: Create a client ovpn profile, optional nopass"
     echo ":::"
-    echo "::: Usage: pivpn <-a|add> [-n|--name <arg>] [-p|--password <arg>]|[nopass] [-d|--days <number>] [-i|--iOS] [-h|--help]"
+    echo "::: Usage: pivpn <-a|add> [-n|--name <arg>] [-p|--password <arg>]|[nopass] [-d|--days <number>] [-b|--bitwarden] [-i|--iOS] [-h|--help]"
     echo ":::"
     echo "::: Commands:"
     echo ":::  [none]               Interactive mode"
     echo ":::  nopass               Create a client without a password"
-    echo ":::  -b,--bitwarden       Create and save a client through Bitwarden"
-    echo ":::  -d,--days            Expire the certificate after specified number of days (default: 1080)"
     echo ":::  -n,--name            Name for the Client (default: '"$(hostname)"')"
     echo ":::  -p,--password        Password for the Client (no default)"
+    echo ":::  -d,--days            Expire the certificate after specified number of days (default: 1080)"
+    echo ":::  -b,--bitwarden       Create and save a client through Bitwarden"
     echo ":::  -i,--iOS             Generate a certificate that leverages iOS keychain"
     echo ":::  -h,--help            Show this help dialog"
 }

--- a/scripts/makeOVPN.sh
+++ b/scripts/makeOVPN.sh
@@ -28,6 +28,12 @@ helpFunc() {
     echo ":::  -h,--help            Show this help dialog"
 }
 
+if [ ! -f /etc/pivpn/HELP_SHOWN ]; then
+    helpFunc
+    echo
+    touch /etc/pivpn/HELP_SHOWN
+fi
+
 # Parse input arguments
 while test $# -gt 0
 do
@@ -342,7 +348,7 @@ if [ "$iOS" = "1" ]; then
 	printf "Please remember the export password\n"
 	printf "as you will need this import the certificate on your iOS device\n"
 	printf "========================================================\n"
-	openssl pkcs12 -passin env:$PASSWD -export -in issued/${NAME}${CRT} -inkey private/${NAME}${KEY} -certfile ${CA} -name ${NAME} -out /home/$INSTALL_USER/ovpns/$NAME.ovpn12
+	openssl pkcs12 -passin pass:"$PASSWD" -export -in "issued/${NAME}${CRT}" -inkey "private/${NAME}${KEY}" -certfile ${CA} -name "${NAME}" -out "/home/$INSTALL_USER/ovpns/$NAME.ovpn12"
 	chown "$INSTALL_USER" "/home/$INSTALL_USER/ovpns/$NAME.ovpn12"
 	chmod 600 "/home/$INSTALL_USER/ovpns/$NAME.ovpn12"
 	printf "========================================================\n"


### PR DESCRIPTION
`-passin env:$PASSWD` reads the password from the `$PASSWD` environment variable, but `$PASSWD` is not an environment variable, it's the actual password. Now using `-passin pass:"$PASSWD"` to fix.

`--bitwarden` option is shown both when running `pivpn` and running `pivpn -a` which seems redundant to me, so I removed it from `pivpn`. However, to make it discoverable, together with `--iOS` and `--days`, we show the client creation options the first time the user runs `pivpn -a`.

