### PR TITLE
Check if -i iOS can be used

### DIFF
--- a/scripts/makeOVPN.sh
+++ b/scripts/makeOVPN.sh
@@ -70,7 +70,13 @@ do
             DAYS="$_val"
             ;;
         -i|--iOS)
-            iOS=1
+			OVPN12_Compatible=$(cat /etc/pivpn/OVPN12_Compatible)
+			if [[ ${OVPN12_Compatible} == "true" ]]; then
+				iOS=1
+			else
+				echo "This function is not compatable with OVPN 2.4"
+				exit 1
+			fi
             ;;
         -h|--help)
             helpFunc


### PR DESCRIPTION
the -i iOS function is not compatible with OVPN 2.4.  This change checks to ensure that the user is not using this version before attempting to create an OVPN12 file.