### PR TITLE
Unattended installation

### DIFF
--- a/Default.txt
+++ b/Default.txt
@@ -4,8 +4,6 @@ proto udp
 remote IPv4pub 1194
 resolv-retry infinite
 nobind
-persist-key
-persist-tun
 key-direction 1
 remote-cert-tls server
 tls-version-min 1.2

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1222,7 +1222,7 @@ confOpenVPN(){
 	# Backup the openvpn folder
 	OPENVPN_BACKUP="openvpn_$(date +%Y-%m-%d-%H%M%S).tar.gz"
 	echo "::: Backing up the openvpn folder to /etc/${OPENVPN_BACKUP}"
-	$SUDO tar czf "/etc/${OPENVPN_BACKUP}" /etc/openvpn
+	$SUDO tar czf "/etc/${OPENVPN_BACKUP}" /etc/openvpn &> /dev/null
 
 	if [ -f /etc/openvpn/server.conf ]; then
 		$SUDO rm /etc/openvpn/server.conf
@@ -1346,7 +1346,7 @@ confWireGuard(){
 		# Backup the wireguard folder
 		WIREGUARD_BACKUP="wireguard_$(date +%Y-%m-%d-%H%M%S).tar.gz"
 		echo "::: Backing up the wireguard folder to /etc/${WIREGUARD_BACKUP}"
-		$SUDO tar czf "/etc/${WIREGUARD_BACKUP}" /etc/wireguard
+		$SUDO tar czf "/etc/${WIREGUARD_BACKUP}" /etc/wireguard &> /dev/null
 
 		if [ -f /etc/wireguard/wg0.conf ]; then
 			$SUDO rm /etc/wireguard/wg0.conf
@@ -1386,7 +1386,7 @@ ListenPort = ${pivpnPORT}" | $SUDO tee /etc/wireguard/wg0.conf &> /dev/null
 confNetwork(){
 	# Enable forwarding of internet traffic
 	$SUDO sed -i '/net.ipv4.ip_forward=1/s/^#//g' /etc/sysctl.conf
-	$SUDO sysctl -p
+	$SUDO sysctl -p > /dev/null
 
 	# if ufw enabled, configure that (running as root because sometimes the executable is not in the user's $PATH, on Debian for example)
 	if $SUDO bash -c 'hash ufw' 2>/dev/null; then
@@ -1708,10 +1708,10 @@ main(){
 	case ${PLAT} in
 		Debian|Raspbian)
 			if [ "$VPN" = "openvpn" ]; then
-				$SUDO systemctl enable openvpn.service
+				$SUDO systemctl enable openvpn.service &> /dev/null
 				$SUDO systemctl start openvpn.service
 			elif [ "$VPN" = "wireguard" ]; then
-				$SUDO systemctl enable wg-quick@wg0.service
+				$SUDO systemctl enable wg-quick@wg0.service &> /dev/null
 				$SUDO systemctl start wg-quick@wg0.service
 			fi
 		;;

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1061,17 +1061,17 @@ validDomain(){
 #This procedure allows a user to specify a custom search domain if they have one.
 askCustomDomain(){
 	if [ "${runUnattended}" = 'true' ]; then
-		if [ -n "$pivpnDOMAIN" ]; then
-			if validDomain "$pivpnDOMAIN"; then
-				echo "::: Using custom domain $pivpnDOMAIN"
+		if [ -n "$pivpnSEARCHDOMAIN" ]; then
+			if validDomain "$pivpnSEARCHDOMAIN"; then
+				echo "::: Using custom domain $pivpnSEARCHDOMAIN"
 			else
-				echo "::: Custom domain $pivpnDOMAIN is not valid"
+				echo "::: Custom domain $pivpnSEARCHDOMAIN is not valid"
 				exit 1
 			fi
 		else
 			echo "::: Skipping custom domain"
 		fi
-		echo "pivpnDOMAIN=${pivpnDOMAIN}" >> /tmp/setupVars.conf
+		echo "pivpnSEARCHDOMAIN=${pivpnSEARCHDOMAIN}" >> /tmp/setupVars.conf
 		return
 	fi
 
@@ -1081,16 +1081,16 @@ askCustomDomain(){
 
 		until [[ $DomainSettingsCorrect = True ]]
 		do
-			if pivpnDOMAIN=$(whiptail --inputbox "Enter Custom Domain\nFormat: mydomain.com" ${r} ${c} --title "Custom Domain" 3>&1 1>&2 2>&3); then
-				if validDomain "$pivpnDOMAIN"; then
-					if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Are these settings correct?\n    Custom Search Domain: $pivpnDOMAIN" ${r} ${c}); then
+			if pivpnSEARCHDOMAIN=$(whiptail --inputbox "Enter Custom Domain\nFormat: mydomain.com" ${r} ${c} --title "Custom Domain" 3>&1 1>&2 2>&3); then
+				if validDomain "$pivpnSEARCHDOMAIN"; then
+					if (whiptail --backtitle "Custom Search Domain" --title "Custom Search Domain" --yesno "Are these settings correct?\n    Custom Search Domain: $pivpnSEARCHDOMAIN" ${r} ${c}); then
 						DomainSettingsCorrect=True
 					else
 						# If the settings are wrong, the loop continues
 						DomainSettingsCorrect=False
 					fi
 				else
-					whiptail --msgbox --backtitle "Invalid Domain" --title "Invalid Domain" "Domain is invalid. Please try again.\n\n    DOMAIN:   $pivpnDOMAIN\n" ${r} ${c}
+					whiptail --msgbox --backtitle "Invalid Domain" --title "Invalid Domain" "Domain is invalid. Please try again.\n\n    DOMAIN:   $pivpnSEARCHDOMAIN\n" ${r} ${c}
 					DomainSettingsCorrect=False
 				fi
 			else
@@ -1100,7 +1100,7 @@ askCustomDomain(){
 		done
 	fi
 
-	echo "pivpnDOMAIN=${pivpnDOMAIN}" >> /tmp/setupVars.conf
+	echo "pivpnSEARCHDOMAIN=${pivpnSEARCHDOMAIN}" >> /tmp/setupVars.conf
 }
 
 askPublicIPOrDNS(){
@@ -1313,8 +1313,8 @@ set_var EASYRSA_KEY_SIZE   ${pivpnENCRYPT}" | $SUDO tee vars >/dev/null
 		$SUDO sed -i "s/proto udp/proto tcp/g" /etc/openvpn/server.conf
 	fi
 
-	if [ -n "$pivpnDOMAIN" ]; then
-		$SUDO sed -i "0,/\(.*dhcp-option.*\)/s//\push \"dhcp-option DOMAIN ${pivpnDOMAIN}\" \n&/" /etc/openvpn/server.conf
+	if [ -n "$pivpnSEARCHDOMAIN" ]; then
+		$SUDO sed -i "0,/\(.*dhcp-option.*\)/s//\push \"dhcp-option DOMAIN ${pivpnSEARCHDOMAIN}\" \n&/" /etc/openvpn/server.conf
 	fi
 
 	# write out server certs to conf file

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -37,9 +37,6 @@ easyrsaRel="https://github.com/OpenVPN/easy-rsa/releases/download/v${easyrsaVer}
 UNATTUPG_RELEASE="1.14"
 UNATTUPG_CONFIG="https://github.com/mvo5/unattended-upgrades/archive/${UNATTUPG_RELEASE}.tar.gz"
 
-WG_SNAPSHOT="0.0.20191012"
-WG_SOURCE="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WG_SNAPSHOT}.tar.xz"
-
 # Find the rows and columns. Will default to 80x24 if it can not be detected.
 screen_size=$(stty size 2>/dev/null || echo 24 80)
 rows=$(echo $screen_size | awk '{print $1}')
@@ -738,8 +735,11 @@ Pin-Priority: 500" | $SUDO tee /etc/apt/preferences.d/limit-unstable > /dev/null
 	elif [ "$(uname -m)" = "armv6l" ]; then
 
 		echo "::: Installing WireGuard from source... "
-		PIVPN_DEPS=(checkinstall dkms libmnl-dev libelf-dev raspberrypi-kernel-headers build-essential pkg-config qrencode)
+		PIVPN_DEPS=(checkinstall dkms libmnl-dev libelf-dev raspberrypi-kernel-headers build-essential pkg-config qrencode jq)
 		installDependentPackages PIVPN_DEPS[@]
+
+		WG_SNAPSHOT="$(curl -s https://build.wireguard.com/distros.json | jq -r '."upstream-kmodtools"."version"')"
+		WG_SOURCE="https://git.zx2c4.com/WireGuard/snapshot/WireGuard-${WG_SNAPSHOT}.tar.xz"
 
 		# Delete any leftover code
 		$SUDO rm -rf /usr/src/wireguard-*
@@ -803,6 +803,8 @@ Pin-Priority: 500" | $SUDO tee /etc/apt/preferences.d/limit-unstable > /dev/null
 			$SUDO dkms remove wireguard/"${WG_SNAPSHOT}" --all
 			exit 1
 		fi
+
+		echo "WG_SNAPSHOT=${WG_SNAPSHOT}" >> /tmp/setupVars.conf
 
 	elif [ "$(uname -m)" = "x86_64" ] || [ "$(uname -m)" = "i686" ]; then
 

--- a/scripts/openvpn/makeOVPN.sh
+++ b/scripts/openvpn/makeOVPN.sh
@@ -213,6 +213,7 @@ EOF
 #make sure ovpns dir exists
 if [ ! -d "$install_home/ovpns" ]; then
     mkdir "$install_home/ovpns"
+    chown "$install_user":"$install_user" "$install_home/ovpns"
     chmod 0750 "$install_home/ovpns"
 fi
 
@@ -339,16 +340,10 @@ if [ "$iOS" = "1" ]; then
     sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' < "issued/${NAME}${CRT}"
     echo "</cert>"
 
-    #Finally, append the TA Private Key
-    if [ -f /etc/pivpn/TWO_POINT_FOUR ]; then
-      echo "<tls-crypt>"
-      cat "${TA}"
-      echo "</tls-crypt>"
-    else
-      echo "<tls-auth>"
-      cat "${TA}"
-      echo "</tls-auth>"
-    fi
+    #Finally, append the tls Private Key
+    echo "<tls-auth>"
+    cat "${TA}"
+    echo "</tls-auth>"
 
 	} > "${NAME}${FILEEXT}"
 
@@ -401,7 +396,7 @@ fi
 
 # Copy the .ovpn profile to the home directory for convenient remote access
 cp "/etc/openvpn/easy-rsa/pki/$NAME$FILEEXT" "$install_home/ovpns/$NAME$FILEEXT"
-chown "$install_user" "$install_home/ovpns/$NAME$FILEEXT"
+chown "$install_user":"$install_user" "$install_home/ovpns/$NAME$FILEEXT"
 chmod 640 "/etc/openvpn/easy-rsa/pki/$NAME$FILEEXT"
 chmod 640 "$install_home/ovpns/$NAME$FILEEXT"
 printf "\n\n"

--- a/scripts/openvpn/pivpnDebug.sh
+++ b/scripts/openvpn/pivpnDebug.sh
@@ -184,7 +184,7 @@ else
     fi
 fi
 
-# grep -w (whole word) is used so port 111940 with now match when looking for 1194
+# grep -w (whole word) is used so port 11940 won't match when looking for 1194
 if netstat -uanpt | grep openvpn | grep -w "${pivpnPORT}" | grep -q "${pivpnPROTO}"; then
     echo ":: [OK] OpenVPN is listening on port ${pivpnPORT}/${pivpnPROTO}"
 else

--- a/scripts/openvpn/pivpnDebug.sh
+++ b/scripts/openvpn/pivpnDebug.sh
@@ -205,7 +205,7 @@ echo -e "::::      \e[4mSnippet of the server log\e[0m      ::::"
 tail -20 /var/log/openvpn.log > /tmp/snippet
 
 # Regular expession taken from https://superuser.com/a/202835, it will match invalid IPs
-# like 123.456.789.012 but it's fine because the log only contains valid ones.
+# like 123.456.789.012 but it's fine since the log only contains valid ones.
 declare -a IPS_TO_HIDE=($(grepcidr -v 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 /tmp/snippet | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | uniq))
 for IP in "${IPS_TO_HIDE[@]}"; do
     sed -i "s/$IP/REDACTED/g" /tmp/snippet

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -67,6 +67,7 @@ removeAll(){
 		ufw delete allow "${pivpnPORT}"/"${pivpnPROTO}" > /dev/null
 		ufw route delete allow in on "${pivpnDEV}" from "${pivpnNET}/24" out on "${IPv4dev}" to any > /dev/null
 		sed -z "s/*nat\n:POSTROUTING ACCEPT \[0:0\]\n-I POSTROUTING -s ${pivpnNET}\/24 -o ${IPv4dev} -j MASQUERADE\nCOMMIT\n\n//" -i /etc/ufw/before.rules
+		iptables -t nat -D POSTROUTING -s "${pivpnNET}/24" -o "${IPv4dev}" -j MASQUERADE
 		ufw reload &> /dev/null
 
 	elif [ "$USING_UFW" -eq 0 ]; then
@@ -77,7 +78,7 @@ removeAll(){
 
 		if [ "$FORWARD_CHAIN_EDITED" -eq 1 ]; then
 			iptables -D FORWARD -d "${pivpnNET}/24" -i "${IPv4dev}" -o "${pivpnDEV}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-			iptables -D FORWARD -s "${pivpnNET}/24" -i "${pivpnDEV}/24" -o "${IPv4dev}" -j ACCEPT
+			iptables -D FORWARD -s "${pivpnNET}/24" -i "${pivpnDEV}" -o "${IPv4dev}" -j ACCEPT
 		fi
 
 		iptables -t nat -D POSTROUTING -s "${pivpnNET}/24" -o "${IPv4dev}" -j MASQUERADE
@@ -103,8 +104,6 @@ removeAll(){
 								rm /etc/apt/preferences.d/limit-unstable
 								$PKG_MANAGER update &> /dev/null
 							fi
-							rm -rf /etc/wireguard
-							rm -rf $install_home/configs
 
 						elif [ "${i}" = "wireguard-dkms" ]; then
 
@@ -122,12 +121,6 @@ removeAll(){
 							# If dirmngr was installed, then we had previously installed wireguard on armv7l
 							# so we remove the repository keys
 							apt-key remove E1CF20DDFFE4B89E802658F1E0B11894F66AEC98 80D15823B7FD1561F9F7BCDDDC30D7C23CBBABEE &> /dev/null
-
-						elif [ "${i}" = "openvpn" ]; then
-
-							rm -rf /var/log/*openvpn*
-							rm -rf /etc/openvpn
-							rm -rf $install_home/ovpns
 
 						elif [ "${i}" = "unattended-upgrades" ]; then
 
@@ -158,7 +151,7 @@ removeAll(){
 	echo "::: Removing pivpn system files..."
 
 	if [ -f /etc/dnsmasq.d/02-pivpn.conf ]; then
-		rm /etc/dnsmasq.d/02-pivpn.conf
+		rm -f /etc/dnsmasq.d/02-pivpn.conf
 		pihole restartdns
 	fi
 
@@ -166,8 +159,24 @@ removeAll(){
 	rm -rf /etc/.pivpn
 	rm -rf /etc/pivpn
 	rm -rf /var/log/*pivpn*
-	rm /usr/local/bin/pivpn
-	rm /etc/bash_completion.d/pivpn
+	rm -f /usr/local/bin/pivpn
+	rm -f /etc/bash_completion.d/pivpn
+
+	echo ":::"
+	echo "::: Removing VPN configuration files..."
+
+	if [ "$VPN" = "wireguard" ]; then
+		rm -f /etc/wireguard/wg0.conf
+		rm -rf /etc/wireguard/configs
+		rm -rf /etc/wireguard/keys
+		rm -rf $install_home/configs
+	elif [ "$VPN" = "openvpn" ]; then
+		rm -rf /var/log/*openvpn*
+		rm -f /etc/openvpn/server.conf
+		rm -f /etc/openvpn/crl.pem
+		rm -rf /etc/openvpn/easy-rsa
+		rm -rf $install_home/ovpns
+	fi
 
 	echo ":::"
 	printf "::: Finished removing PiVPN from your system.\n"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -2,7 +2,6 @@
 # PiVPN: Uninstall Script
 
 PKG_MANAGER="apt-get"
-WG_SNAPSHOT="0.0.20191012"
 setupVars="/etc/pivpn/setupVars.conf"
 
 if [ ! -f "${setupVars}" ]; then

--- a/scripts/wireguard/pivpnDEBUG.sh
+++ b/scripts/wireguard/pivpnDEBUG.sh
@@ -24,7 +24,7 @@ printf "=============================================\n"
 echo -e "::::  \e[4mServer configuration shown below\e[0m   ::::"
 cd /etc/wireguard/keys
 cp ../wg0.conf ../wg0.tmp
-# Replace every key in the server configuration with just it's file name
+# Replace every key in the server configuration with just its file name
 for k in *; do
     sed "s#$(cat "$k")#$k#" -i ../wg0.tmp
 done

--- a/server_config.txt
+++ b/server_config.txt
@@ -17,7 +17,7 @@ push "block-outside-dns"
 # overriding but not wiping out the original default gateway.
 push "redirect-gateway def1"
 client-to-client
-keepalive 1800 3600
+keepalive 15 120
 remote-cert-tls client
 tls-version-min 1.2
 tls-auth /etc/openvpn/easy-rsa/pki/ta.key 0

--- a/unattended_openvpn_example.conf
+++ b/unattended_openvpn_example.conf
@@ -1,0 +1,12 @@
+IPv4dev=eth0
+install_user=pi
+VPN=openvpn
+pivpnPROTO=udp
+pivpnPORT=1194
+pivpnDNS1=8.8.8.8
+pivpnDNS2=8.8.4.4
+pivpnHOST=pivpn.example.com
+pivpnENCRYPT=2048
+pivpnDOMAIN=domain.example.com
+DOWNLOAD_DH_PARAM=0
+UNATTUPG=1

--- a/unattended_openvpn_example.conf
+++ b/unattended_openvpn_example.conf
@@ -7,6 +7,6 @@ pivpnDNS1=8.8.8.8
 pivpnDNS2=8.8.4.4
 pivpnHOST=pivpn.example.com
 pivpnENCRYPT=2048
-pivpnDOMAIN=domain.example.com
+pivpnSEARCHDOMAIN=searchdomain.example.com
 DOWNLOAD_DH_PARAM=0
 UNATTUPG=1

--- a/unattended_wireguard_example.conf
+++ b/unattended_wireguard_example.conf
@@ -1,0 +1,8 @@
+IPv4dev=eth0
+install_user=pi
+VPN=wireguard
+pivpnPORT=51820
+pivpnDNS1=8.8.8.8
+pivpnDNS2=8.8.4.4
+pivpnHOST=pivpn.example.com
+UNATTUPG=1


### PR DESCRIPTION
Changes:
1) Added back unattended installation: as expected, the user can call the install script with `--unattended` followed by a config file and PiVPN will be installed non-interactively. Two examples are provided in case the user wants to customize every setting. However you don't need to specify all of them, missing one are filled with defaults IF those settings can be detected unambiguously. For example if you only have one user and one network interface the script proceeds, however if you have several of them it does not.
2) Removed `persist-key` and `persist-tun` from the client config.
3) Reverted `keepalive` setting on the server to smaller values.
See @TinCanTech's posts for the reasons of the above two: https://github.com/pivpn/pivpn/issues/864#issuecomment-553496345
4) Copied `validDomain()` function from the test branch.
5) Removed 1024 bit certificate options, since on Buster OpenVPN does not start with such small certificates (I think it's related to OpenSSL 1.1.1).
6) Backup `/etc/openvpn` and `/etc/wireguard` before installing.
7) Always remove VPN configuration when uninstalling, but do not wipe the folder, just remove what PiVPN added.
8) Fetch latest WireGuard snapshot instead of hardcoding it into the script.