### PR TITLE
Revert some minor changes

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1432,10 +1432,10 @@ confNetwork(){
 			fi
 			### If there is already a "*nat" section just add our POSTROUTING MASQUERADE
 			if $SUDO grep -q "*nat" /etc/ufw/before.rules; then
-				$SUDO sed "/^*nat/{n;s/\(:POSTROUTING ACCEPT .*\)/\1\n-I POSTROUTING -s ${pivpnNET}\/24 -o ${IPv4dev} -j MASQUERADE/}" -i /etc/ufw/before.rules
+				$SUDO sed "/^*nat/{n;s/\(:POSTROUTING ACCEPT .*\)/\1\n-I POSTROUTING -s ${pivpnNET}\/${subnetClass} -o ${IPv4dev} -j MASQUERADE/}" -i /etc/ufw/before.rules
 			else
-        $SUDO sed "/delete these required/i *nat\n:POSTROUTING ACCEPT [0:0]\n-I POSTROUTING -s ${pivpnNET}\/${subnetClass} -o ${IPv4dev} -j MASQUERADE\nCOMMIT\n" -i /etc/ufw/before.rules
-      fi
+				$SUDO sed "/delete these required/i *nat\n:POSTROUTING ACCEPT [0:0]\n-I POSTROUTING -s ${pivpnNET}\/${subnetClass} -o ${IPv4dev} -j MASQUERADE\nCOMMIT\n" -i /etc/ufw/before.rules
+			fi
 			# Insert rules at the beginning of the chain (in case there are other rules that may drop the traffic)
 			$SUDO ufw insert 1 allow "${pivpnPORT}"/"${pivpnPROTO}" >/dev/null
 			$SUDO ufw route insert 1 allow in on "${pivpnDEV}" from "${pivpnNET}/${subnetClass}" out on "${IPv4dev}" to any >/dev/null

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -19,6 +19,7 @@ debianOvpnUserGroup="openvpn:openvpn"
 ### PKG Vars ###
 PKG_MANAGER="apt-get"
 PKG_CACHE="/var/lib/apt/lists/"
+### FIXME: quoting UPDATE_PKG_CACHE and PKG_INSTALL hangs the script, shellcheck SC2086
 UPDATE_PKG_CACHE="${PKG_MANAGER} update"
 PKG_INSTALL="${PKG_MANAGER} --yes --no-install-recommends install"
 PKG_COUNT="${PKG_MANAGER} -s -o Debug::NoLocking=true upgrade | grep -c ^Inst || true"
@@ -1308,8 +1309,7 @@ set_var EASYRSA_KEY_SIZE   ${pivpnENCRYPT}" | $SUDO tee vars >/dev/null
 	${SUDOE} ./easyrsa gen-crl
 	${SUDOE} cp pki/crl.pem /etc/openvpn/crl.pem
   if ! getent passwd openvpn; then
-    mkdir -p /var/lib/openvpn
-    ${SUDOE} adduser --system --home /var/lib/openvpn/ --no-create-home --group --disabled-login ${debianOvpnUserGroup%:*}
+    ${SUDOE} adduser --system --home /var/lib/openvpn/ --group --disabled-login ${debianOvpnUserGroup%:*}
   fi
   ${SUDOE} chown "$debianOvpnUserGroup" /etc/openvpn/crl.pem
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -5,6 +5,7 @@
 ### FIXME: use variables where appropriate, reduce magic numbers by 99.9%, at least.
 
 PKG_MANAGER="apt-get"
+subnetClass="24"
 setupVars="/etc/pivpn/setupVars.conf"
 
 if [ ! -f "${setupVars}" ]; then
@@ -72,9 +73,9 @@ removeAll(){
     ### FIXME: SC2154
 		ufw delete allow "${pivpnPORT}"/"${pivpnPROTO}" > /dev/null
     ### FIXME: SC2154
-		ufw route delete allow in on "${pivpnDEV}" from "${pivpnNET}/24" out on "${IPv4dev}" to any > /dev/null
-		sed -z "s/*nat\\n:POSTROUTING ACCEPT \\[0:0\\]\\n-I POSTROUTING -s ${pivpnNET}\\/24 -o ${IPv4dev} -j MASQUERADE\\nCOMMIT\\n\\n//" -i /etc/ufw/before.rules
-		iptables -t nat -D POSTROUTING -s "${pivpnNET}/24" -o "${IPv4dev}" -j MASQUERADE
+		ufw route delete allow in on "${pivpnDEV}" from "${pivpnNET}/${subnetClass}" out on "${IPv4dev}" to any > /dev/null
+		sed -z "s/*nat\\n:POSTROUTING ACCEPT \\[0:0\\]\\n-I POSTROUTING -s ${pivpnNET}\\/${subnetClass} -o ${IPv4dev} -j MASQUERADE\\nCOMMIT\\n\\n//" -i /etc/ufw/before.rules
+		iptables -t nat -D POSTROUTING -s "${pivpnNET}/${subnetClass}" -o "${IPv4dev}" -j MASQUERADE
 		ufw reload &> /dev/null
 
 	elif [ "$USING_UFW" -eq 0 ]; then
@@ -84,11 +85,11 @@ removeAll(){
 		fi
 
 		if [ "$FORWARD_CHAIN_EDITED" -eq 1 ]; then
-			iptables -D FORWARD -d "${pivpnNET}/24" -i "${IPv4dev}" -o "${pivpnDEV}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-			iptables -D FORWARD -s "${pivpnNET}/24" -i "${pivpnDEV}" -o "${IPv4dev}" -j ACCEPT
+			iptables -D FORWARD -d "${pivpnNET}/${subnetClass}" -i "${IPv4dev}" -o "${pivpnDEV}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+			iptables -D FORWARD -s "${pivpnNET}/${subnetClass}" -i "${pivpnDEV}" -o "${IPv4dev}" -j ACCEPT
 		fi
 
-		iptables -t nat -D POSTROUTING -s "${pivpnNET}/24" -o "${IPv4dev}" -j MASQUERADE
+		iptables -t nat -D POSTROUTING -s "${pivpnNET}/${subnetClass}" -o "${IPv4dev}" -j MASQUERADE
 		iptables-save > /etc/iptables/rules.v4
 
 	fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -181,16 +181,16 @@ removeAll(){
 
 	if [ "$VPN" = "wireguard" ]; then
 		rm -f /etc/wireguard/wg0.conf
-		rm -f /etc/wireguard/configs
-		rm -f /etc/wireguard/keys
+		rm -rf /etc/wireguard/configs
+		rm -rf /etc/wireguard/keys
     ### FIXME SC2154
-		rm -f "$install_home/configs"
+		rm -rf "$install_home/configs"
 	elif [ "$VPN" = "openvpn" ]; then
 		rm -f /var/log/*openvpn*
 		rm -f /etc/openvpn/server.conf
 		rm -f /etc/openvpn/crl.pem
-		rm -f /etc/openvpn/easy-rsa
-		rm -f "$install_home/ovpns"
+		rm -rf /etc/openvpn/easy-rsa
+		rm -rf "$install_home/ovpns"
 	fi
 
 	echo ":::"

--- a/server_config.txt
+++ b/server_config.txt
@@ -23,8 +23,8 @@ tls-version-min 1.2
 tls-auth /etc/openvpn/easy-rsa/pki/ta.key 0
 cipher AES-256-CBC
 auth SHA256
-user nobody
-group nogroup
+user openvpn
+group openvpn
 persist-key
 persist-tun
 crl-verify /etc/openvpn/crl.pem


### PR DESCRIPTION
- Unquoted ${PKG_INSTALL} and ${UPDATE_PKG_CACHE} as they seem to hang the script if quoted.
- Removed [this code](https://github.com/pivpn/pivpn/compare/test...orazioedoardo:test?expand=1#diff-299d9b30c952310aace4aba77c698874L285-L294) as set -e is not used in the test branch and even if it were used, the script would exit if `debconf-apt-progress`'s exit code is NOT 100 (which is the case when no errors occur, exit code 0).
- `vpnGw="${pivpnNET/.0/.1}"` turns 10.8.0.0 into 10.8.1.0 however we need 10.8.0.1 so `vpnGw="${pivpnNET/.0.0/.0.1}"` is used.
- Create folder /var/lib/openvpn
- Removed code path related to OLD_UFW, originally used for jessie compatibility
- Other trivial changes
@corbolais what do you think?