### PR TITLE
Merge test into master

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -425,8 +425,8 @@ notifyPackageUpdatesAvailable(){
 preconfigurePackages(){
 	# Add support for https repositories that will be used later on
 	if [[ -f /etc/apt/sources.list ]]; then
-		# Only on stretch because on buster apt already support https transport
-		if [[ ${OSCN} == "stretch" ]]; then
+		# buster and bionic have apt >= 1.5 which has https support built in
+		if [[ ${OSCN} != "buster" ]] && [[ ${OSCN} != "bionic" ]]; then
 			BASE_DEPS+=("apt-transport-https")
 		fi
 	fi
@@ -439,7 +439,7 @@ preconfigurePackages(){
 	# if ufw is enabled, configure that.
 	# running as root because sometimes the executable is not in the user's $PATH
 	if $SUDO bash -c 'command -v ufw' > /dev/null; then
-		if LANG=en_US.UTF-8 $SUDO ufw status | grep -q inactive; then
+		if LC_ALL=C $SUDO ufw status | grep -q inactive; then
 			USING_UFW=0
 		else
 			USING_UFW=1

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1445,10 +1445,16 @@ askClientDNS(){
 			# Then create an empty hosts file or clear if it exists.
 			$SUDO bash -c "> /etc/pivpn/hosts.$VPN"
 
-			# If the listening behavior is "Listen only on interface whatever", tell dnsmasq
-			# to listen on the VPN interface as well. Other listening behaviors are permissive
-			# enough.
-			if [ "$(source "$piholeSetupVars" && echo "${DNSMASQ_LISTENING}")" = "single" ]; then
+			# If the listening behavior is "Listen only on interface whatever", which is the
+			# default, tell dnsmasq to listen on the VPN interface as well. Other listening
+			# behaviors are permissive enough.
+
+			# Source in a subshell to prevent overwriting script's variables
+			DNSMASQ_LISTENING="$(source "$piholeSetupVars" && echo "${DNSMASQ_LISTENING}")"
+
+			# $DNSMASQ_LISTENING is not set if you never edit/save settings in the DNS page,
+			# so if the variable is empty, we still add the 'interface=' directive.
+			if [ -z "${DNSMASQ_LISTENING}" ] || [ "${DNSMASQ_LISTENING}" = "single" ]; then
 				echo "interface=$pivpnDEV" | $SUDO tee -a "$dnsmasqConfig" > /dev/null
 			fi
 

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -418,12 +418,13 @@ notifyPackageUpdatesAvailable(){
 }
 
 preconfigurePackages(){
-	# Add support for https repositories if there are any that use it otherwise the installation will silently fail
-  if [[ -f /etc/apt/sources.list ]]; then
-		if grep -q https /etc/apt/sources.list; then
-	  	BASE_DEPS+=("apt-transport-https")
+	# Add support for https repositories that will be used later on
+	if [[ -f /etc/apt/sources.list ]]; then
+		# Only on stretch because on buster apt already support https transport
+		if [[ ${OSCN} == "stretch" ]]; then
+			BASE_DEPS+=("apt-transport-https")
 		fi
-  fi
+	fi
 
 	if [[ ${OSCN} == "buster" ]]; then
 		$SUDO update-alternatives --set iptables /usr/sbin/iptables-legacy

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1173,7 +1173,7 @@ installWireGuard(){
 		elif [ "$(uname -m)" = "armv6l" ]; then
 
 			echo "::: Installing WireGuard from source... "
-			PIVPN_DEPS=(checkinstall dkms libmnl-dev libelf-dev raspberrypi-kernel-headers build-essential pkg-config qrencode jq)
+			PIVPN_DEPS=(checkinstall dkms libelf-dev raspberrypi-kernel-headers build-essential pkg-config qrencode jq)
 			installDependentPackages PIVPN_DEPS[@]
 
 			# Delete any leftover code

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -14,6 +14,7 @@
 pivpnGitUrl="https://github.com/pivpn/pivpn.git"
 setupVars="/etc/pivpn/setupVars.conf"
 pivpnFilesDir="/etc/.pivpn"
+dnsmasqConfig="/etc/dnsmasq.d/02-pivpn.conf"
 
 ### PKG Vars ###
 PKG_MANAGER="apt-get"
@@ -1417,8 +1418,10 @@ askClientDNS(){
 	# Detect and offer to use Pi-hole
 	if command -v pihole > /dev/null; then
 		if (whiptail --backtitle "Setup PiVPN" --title "Pi-hole" --yesno "We have detected a Pi-hole installation, do you want to use it as the DNS server for the VPN, so you get ad blocking on the go?" ${r} ${c}); then
+			echo "interface=$pivpnDEV" | $SUDO tee "$dnsmasqConfig" > /dev/null
+			echo "addn-hosts=/etc/pivpn/hosts.$VPN" | $SUDO tee -a "$dnsmasqConfig" > /dev/null
+			$SUDO bash -c "> /etc/pivpn/hosts.$VPN"
 			pivpnDNS1="$vpnGw"
-			echo "interface=$pivpnDEV" | $SUDO tee /etc/dnsmasq.d/02-pivpn.conf > /dev/null
 			echo "pivpnDNS1=${pivpnDNS1}" >> /tmp/setupVars.conf
 			echo "pivpnDNS2=${pivpnDNS2}" >> /tmp/setupVars.conf
 			return
@@ -2078,7 +2081,7 @@ restartServices(){
 		;;
 	esac
 
-	if [ -f /etc/dnsmasq.d/02-pivpn.conf ]; then
+	if [ -f "$dnsmasqConfig" ]; then
 		$SUDO pihole restartdns
 	fi
 }

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1735,7 +1735,10 @@ confOpenVPN(){
 	# Backup the openvpn folder
 	OPENVPN_BACKUP="openvpn_$(date +%Y-%m-%d-%H%M%S).tar.gz"
 	echo "::: Backing up the openvpn folder to /etc/${OPENVPN_BACKUP}"
+	CURRENT_UMASK=$(umask)
+	umask 0077
 	$SUDO tar czf "/etc/${OPENVPN_BACKUP}" /etc/openvpn &> /dev/null
+	umask "$CURRENT_UMASK"
 
 	if [ -f /etc/openvpn/server.conf ]; then
 		$SUDO rm /etc/openvpn/server.conf
@@ -1912,7 +1915,10 @@ confWireGuard(){
 		# Backup the wireguard folder
 		WIREGUARD_BACKUP="wireguard_$(date +%Y-%m-%d-%H%M%S).tar.gz"
 		echo "::: Backing up the wireguard folder to /etc/${WIREGUARD_BACKUP}"
+		CURRENT_UMASK=$(umask)
+		umask 0077
 		$SUDO tar czf "/etc/${WIREGUARD_BACKUP}" /etc/wireguard &> /dev/null
+		umask "$CURRENT_UMASK"
 
 		if [ -f /etc/wireguard/wg0.conf ]; then
 			$SUDO rm /etc/wireguard/wg0.conf

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1740,6 +1740,13 @@ confOpenVPN(){
 		$SUDO rm /etc/openvpn/server.conf
 	fi
 
+	if [ -d /etc/openvpn/ccd ]; then
+		$SUDO rm -rf /etc/openvpn/ccd
+	fi
+
+	# Create folder to store client specific directives used to push static IPs
+	$SUDO mkdir /etc/openvpn/ccd
+
 	# If easy-rsa exists, remove it
 	if [[ -d /etc/openvpn/easy-rsa/ ]]; then
 		$SUDO rm -rf /etc/openvpn/easy-rsa/

--- a/files/etc/openvpn/server_config.txt
+++ b/files/etc/openvpn/server_config.txt
@@ -17,6 +17,7 @@ push "block-outside-dns"
 # overriding but not wiping out the original default gateway.
 push "redirect-gateway def1"
 client-to-client
+client-config-dir /etc/openvpn/ccd
 keepalive 15 120
 remote-cert-tls client
 tls-version-min 1.2

--- a/scripts/openvpn/makeOVPN.sh
+++ b/scripts/openvpn/makeOVPN.sh
@@ -405,6 +405,17 @@ else
 
 fi
 
+# Find an unused number for the last octet of the client IP
+for i in {2..254}; do
+    # find returns 0 if the folder is empty, so we create the 'ls -A [...]'
+    # exception to stop at the first static IP (10.8.0.2). Otherwise it would
+    # cycle to the end without finding and available octet.
+    if [ -z "$(ls -A /etc/openvpn/ccd)" ] || ! find /etc/openvpn/ccd -type f -exec grep -q "10.8.0.$i" {} +; then
+        COUNT="$i"
+        echo "ifconfig-push 10.8.0.$i 255.255.255.0" >> /etc/openvpn/ccd/"${NAME}"
+        break
+    fi
+done
 
 # Copy the .ovpn profile to the home directory for convenient remote access
 cp "/etc/openvpn/easy-rsa/pki/$NAME$FILEEXT" "$install_home/ovpns/$NAME$FILEEXT"

--- a/scripts/openvpn/makeOVPN.sh
+++ b/scripts/openvpn/makeOVPN.sh
@@ -405,20 +405,29 @@ else
 
 fi
 
+cidrToMask(){
+	# Source: https://stackoverflow.com/a/20767392
+	set -- $(( 5 - ($1 / 8) )) 255 255 255 255 $(( (255 << (8 - ($1 % 8))) & 255 )) 0 0 0
+	[ $1 -gt 1 ] && shift $1 || shift
+	echo ${1-0}.${2-0}.${3-0}.${4-0}
+}
+
+NET_REDUCED="${pivpnNET::-2}"
+
 # Find an unused number for the last octet of the client IP
 for i in {2..254}; do
     # find returns 0 if the folder is empty, so we create the 'ls -A [...]'
     # exception to stop at the first static IP (10.8.0.2). Otherwise it would
     # cycle to the end without finding and available octet.
-    if [ -z "$(ls -A /etc/openvpn/ccd)" ] || ! find /etc/openvpn/ccd -type f -exec grep -q "10.8.0.$i" {} +; then
-        COUNT="$i"
-        echo "ifconfig-push 10.8.0.$i 255.255.255.0" >> /etc/openvpn/ccd/"${NAME}"
+    if [ -z "$(ls -A /etc/openvpn/ccd)" ] || ! find /etc/openvpn/ccd -type f -exec grep -q "${NET_REDUCED}.${i}" {} +; then
+        COUNT="${i}"
+        echo "ifconfig-push ${NET_REDUCED}.${i} $(cidrToMask "$subnetClass")" >> /etc/openvpn/ccd/"${NAME}"
         break
     fi
 done
 
 if [ -f /etc/pivpn/hosts.openvpn ]; then
-    echo "10.8.0.${COUNT} ${NAME}.pivpn" >> /etc/pivpn/hosts.openvpn
+    echo "${NET_REDUCED}.${COUNT} ${NAME}.pivpn" >> /etc/pivpn/hosts.openvpn
     if killall -SIGHUP pihole-FTL; then
         echo "::: Updated hosts file for Pi-hole"
     else

--- a/scripts/openvpn/makeOVPN.sh
+++ b/scripts/openvpn/makeOVPN.sh
@@ -417,6 +417,15 @@ for i in {2..254}; do
     fi
 done
 
+if [ -f /etc/pivpn/hosts.openvpn ]; then
+    echo "10.8.0.${COUNT} ${NAME}.pivpn" >> /etc/pivpn/hosts.openvpn
+    if killall -SIGHUP pihole-FTL; then
+        echo "::: Updated hosts file for Pi-hole"
+    else
+        echo "::: Failed to reload pihole-FTL configuration"
+    fi
+fi
+
 # Copy the .ovpn profile to the home directory for convenient remote access
 cp "/etc/openvpn/easy-rsa/pki/$NAME$FILEEXT" "$install_home/ovpns/$NAME$FILEEXT"
 chown "$install_user":"$install_user" "$install_home/ovpns/$NAME$FILEEXT"

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -119,6 +119,9 @@ for (( ii = 0; ii < ${#CERTS_TO_REVOKE[@]}; ii++)); do
     rm -rf "pki/reqs/${CERTS_TO_REVOKE[ii]}.req"
     rm -rf "pki/private/${CERTS_TO_REVOKE[ii]}.key"
     rm -rf "pki/issued/${CERTS_TO_REVOKE[ii]}.crt"
+
+    # Grab the client IP address
+    STATIC_IP=$(grep -v "^#" /etc/openvpn/ccd/"${CERTS_TO_REVOKE[ii]}" | grep -w ifconfig-push | grep -oE '10.8.0\.[0-9]{1,3}')
     rm -rf /etc/openvpn/ccd/"${CERTS_TO_REVOKE[ii]}"
 
     rm -rf "${install_home}/ovpns/${CERTS_TO_REVOKE[ii]}.ovpn"
@@ -127,8 +130,6 @@ for (( ii = 0; ii < ${#CERTS_TO_REVOKE[@]}; ii++)); do
 
     # If using Pi-hole, remove the client from the hosts file
     if [ -f /etc/pivpn/hosts.openvpn ]; then
-        # Grab the client IP address
-        STATIC_IP=$(awk '{print $2}' <<< /etc/openvpn/ccd/"${CERTS_TO_REVOKE[ii]}")
         sed "\#${STATIC_IP} ${CERTS_TO_REVOKE[ii]}.pivpn#d" -i /etc/pivpn/hosts.openvpn
         if killall -SIGHUP pihole-FTL; then
             echo "::: Updated hosts file for Pi-hole"

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -124,5 +124,17 @@ for (( ii = 0; ii < ${#CERTS_TO_REVOKE[@]}; ii++)); do
     rm -rf "${install_home}/ovpns/${CERTS_TO_REVOKE[ii]}.ovpn"
     rm -rf "/etc/openvpn/easy-rsa/pki/${CERTS_TO_REVOKE[ii]}.ovpn"
     cp /etc/openvpn/easy-rsa/pki/crl.pem /etc/openvpn/crl.pem
+
+    # If using Pi-hole, remove the client from the hosts file
+    if [ -f /etc/pivpn/hosts.openvpn ]; then
+        # Grab the client IP address
+        STATIC_IP=$(awk '{print $2}' <<< /etc/openvpn/ccd/"${CERTS_TO_REVOKE[ii]}")
+        sed "\#${STATIC_IP} ${CERTS_TO_REVOKE[ii]}.pivpn#d" -i /etc/pivpn/hosts.openvpn
+        if killall -SIGHUP pihole-FTL; then
+            echo "::: Updated hosts file for Pi-hole"
+        else
+            echo "::: Failed to reload pihole-FTL configuration"
+        fi
+    fi
 done
 printf "::: Completed!\n"

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -119,6 +119,7 @@ for (( ii = 0; ii < ${#CERTS_TO_REVOKE[@]}; ii++)); do
     rm -rf "pki/reqs/${CERTS_TO_REVOKE[ii]}.req"
     rm -rf "pki/private/${CERTS_TO_REVOKE[ii]}.key"
     rm -rf "pki/issued/${CERTS_TO_REVOKE[ii]}.crt"
+    rm -rf /etc/openvpn/ccd/"${CERTS_TO_REVOKE[ii]}"
 
     rm -rf "${install_home}/ovpns/${CERTS_TO_REVOKE[ii]}.ovpn"
     rm -rf "/etc/openvpn/easy-rsa/pki/${CERTS_TO_REVOKE[ii]}.ovpn"

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -121,7 +121,8 @@ for (( ii = 0; ii < ${#CERTS_TO_REVOKE[@]}; ii++)); do
     rm -rf "pki/issued/${CERTS_TO_REVOKE[ii]}.crt"
 
     # Grab the client IP address
-    STATIC_IP=$(grep -v "^#" /etc/openvpn/ccd/"${CERTS_TO_REVOKE[ii]}" | grep -w ifconfig-push | grep -oE '10.8.0\.[0-9]{1,3}')
+    NET_REDUCED="${pivpnNET::-2}"
+    STATIC_IP=$(grep -v "^#" /etc/openvpn/ccd/"${CERTS_TO_REVOKE[ii]}" | grep -w ifconfig-push | grep -oE "${NET_REDUCED}\.[0-9]{1,3}")
     rm -rf /etc/openvpn/ccd/"${CERTS_TO_REVOKE[ii]}"
 
     rm -rf "${install_home}/ovpns/${CERTS_TO_REVOKE[ii]}.ovpn"

--- a/scripts/self_check.sh
+++ b/scripts/self_check.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-subnetClass="24"
 setupVars="/etc/pivpn/setupVars.conf"
 ERR=0
 
@@ -12,14 +11,9 @@ fi
 source "${setupVars}"
 
 if [ "$VPN" = "wireguard" ]; then
-	pivpnPROTO="udp"
-	pivpnDEV="wg0"
-	pivpnNET="10.6.0.0"
 	VPN_SERVICE="wg-quick@wg0"
 	VPN_PRETTY_NAME="WireGuard"
 elif [ "$VPN" = "openvpn" ]; then
-	pivpnDEV="tun0"
-	pivpnNET="10.8.0.0"
 	VPN_SERVICE="openvpn"
 	VPN_PRETTY_NAME="OpenVPN"
 fi

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -6,7 +6,6 @@
 
 PKG_MANAGER="apt-get"
 UPDATE_PKG_CACHE="${PKG_MANAGER} update"
-subnetClass="24"
 dnsmasqConfig="/etc/dnsmasq.d/02-pivpn.conf"
 setupVars="/etc/pivpn/setupVars.conf"
 
@@ -59,16 +58,6 @@ removeAll(){
 
 	# Removing firewall rules.
 	echo "::: Removing firewall rules..."
-
-  ### FIXME: introduce global config space!
-	if [ "$VPN" = "wireguard" ]; then
-		pivpnPROTO="udp"
-		pivpnDEV="wg0"
-		pivpnNET="10.6.0.0"
-	elif [ "$VPN" = "openvpn" ]; then
-		pivpnDEV="tun0"
-		pivpnNET="10.8.0.0"
-	fi
 
 	if [ "$USING_UFW" -eq 1 ]; then
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -203,6 +203,7 @@ removeAll(){
 		rm -f /etc/openvpn/server.conf
 		rm -f /etc/openvpn/crl.pem
 		rm -rf /etc/openvpn/easy-rsa
+		rm -rf /etc/openvpn/ccd
 		rm -rf "$install_home/ovpns"
 	fi
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -7,6 +7,7 @@
 PKG_MANAGER="apt-get"
 UPDATE_PKG_CACHE="${PKG_MANAGER} update"
 subnetClass="24"
+dnsmasqConfig="/etc/dnsmasq.d/02-pivpn.conf"
 setupVars="/etc/pivpn/setupVars.conf"
 
 if [ ! -f "${setupVars}" ]; then
@@ -176,8 +177,8 @@ removeAll(){
 	# Removing pivpn files
 	echo "::: Removing pivpn system files..."
 
-	if [ -f /etc/dnsmasq.d/02-pivpn.conf ]; then
-		rm -f /etc/dnsmasq.d/02-pivpn.conf
+	if [ -f "$dnsmasqConfig" ]; then
+		rm -f "$dnsmasqConfig"
 		pihole restartdns
 	fi
 

--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -113,6 +113,15 @@ AllowedIPs = 10.6.0.${COUNT}/32
 # end ${CLIENT_NAME}" >> wg0.conf
 echo "::: Updated server config"
 
+if [ -f /etc/pivpn/hosts.wireguard ]; then
+    echo "10.6.0.${COUNT} ${CLIENT_NAME}.pivpn" >> /etc/pivpn/hosts.wireguard
+    if killall -SIGHUP pihole-FTL; then
+        echo "::: Updated hosts file for Pi-hole"
+    else
+        echo "::: Failed to reload pihole-FTL configuration"
+    fi
+fi
+
 if systemctl restart wg-quick@wg0; then
     echo "::: WireGuard restarted"
 else

--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -86,9 +86,11 @@ for i in {2..254}; do
     fi
 done
 
+NET_REDUCED="${pivpnNET::-2}"
+
 echo -n "[Interface]
 PrivateKey = $(cat "keys/${CLIENT_NAME}_priv")
-Address = 10.6.0.${COUNT}/24
+Address = ${NET_REDUCED}.${COUNT}/${subnetClass}
 DNS = ${pivpnDNS1}" > "configs/${CLIENT_NAME}.conf"
 
 if [ -n "${pivpnDNS2}" ]; then
@@ -109,12 +111,12 @@ echo "# begin ${CLIENT_NAME}
 [Peer]
 PublicKey = $(cat "keys/${CLIENT_NAME}_pub")
 PresharedKey = $(cat keys/psk)
-AllowedIPs = 10.6.0.${COUNT}/32
+AllowedIPs = ${NET_REDUCED}.${COUNT}/32
 # end ${CLIENT_NAME}" >> wg0.conf
 echo "::: Updated server config"
 
 if [ -f /etc/pivpn/hosts.wireguard ]; then
-    echo "10.6.0.${COUNT} ${CLIENT_NAME}.pivpn" >> /etc/pivpn/hosts.wireguard
+    echo "${NET_REDUCED}.${COUNT} ${CLIENT_NAME}.pivpn" >> /etc/pivpn/hosts.wireguard
     if killall -SIGHUP pihole-FTL; then
         echo "::: Updated hosts file for Pi-hole"
     else

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -106,7 +106,8 @@ for CLIENT_NAME in "${CLIENTS_TO_REMOVE[@]}"; do
 
             # If using Pi-hole, remove the client from the hosts file
             if [ -f /etc/pivpn/hosts.wireguard ]; then
-                sed "\#10.6.0.${COUNT} ${CLIENT_NAME}.pivpn#d" -i /etc/pivpn/hosts.wireguard
+                NET_REDUCED="${pivpnNET::-2}"
+                sed "\#${NET_REDUCED}.${COUNT} ${CLIENT_NAME}.pivpn#d" -i /etc/pivpn/hosts.wireguard
                 if killall -SIGHUP pihole-FTL; then
                     echo "::: Updated hosts file for Pi-hole"
                 else

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -101,9 +101,19 @@ for CLIENT_NAME in "${CLIENTS_TO_REMOVE[@]}"; do
                 fi
             done
 
+            ((DELETED_COUNT++))
             echo "::: Successfully deleted ${CLIENT_NAME}"
 
-            ((DELETED_COUNT++))
+            # If using Pi-hole, remove the client from the hosts file
+            if [ -f /etc/pivpn/hosts.wireguard ]; then
+                sed "\#10.6.0.${COUNT} ${CLIENT_NAME}.pivpn#d" -i /etc/pivpn/hosts.wireguard
+                if killall -SIGHUP pihole-FTL; then
+                    echo "::: Updated hosts file for Pi-hole"
+                else
+                    echo "::: Failed to reload pihole-FTL configuration"
+                fi
+            fi
+
         fi
     fi
 


### PR DESCRIPTION
Main changes from the test branch:
1) When offering to use Pi-hole, identify VPN clients via clientname.pivpn using a dedicated hosts file. Clients can now be resolved by their names and also show up in the Pi-hole dashboard.
2) Decide whether to tell dnsmasq to listen on the VPN interface depending on the user settings. The default Pi-hole listening behavior is "Listen only on interface whatever", which means we need to add the specific VPN interface. However, if the user has  "Listen on all interfaces" or " "Listen on all interfaces, permit all origin", then we don't need to add the interface (self-explanatory).
3) Set static IPs by default when using OpenVPN, (required by 2.).
4) Restrict access to automatic backups (.tar.gz) of /etc/wireguard and /etc/openvpn to root.