### PR TITLE
Generate unique pre-shared key for each client

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1977,9 +1977,9 @@ confWireGuard(){
 	$SUDO chmod 700 /etc/wireguard
 
 	if [ "${runUnattended}" = 'true' ]; then
-		echo "::: The Server Keys and Pre-Shared key will now be generated."
+		echo "::: The Server Keys will now be generated."
 	else
-		whiptail --title "Server Information" --msgbox "The Server Keys and Pre-Shared key will now be generated." "${r}" "${c}"
+		whiptail --title "Server Information" --msgbox "The Server Keys will now be generated." "${r}" "${c}"
 	fi
 
 	# Remove configs and keys folders to make space for a new server when using 'Repair' or 'Reconfigure'
@@ -1993,10 +1993,9 @@ confWireGuard(){
 
 	# Generate private key and derive public key from it
 	wg genkey | $SUDO tee /etc/wireguard/keys/server_priv &> /dev/null
-	wg genpsk | $SUDO tee /etc/wireguard/keys/psk &> /dev/null
 	$SUDO cat /etc/wireguard/keys/server_priv | wg pubkey | $SUDO tee /etc/wireguard/keys/server_pub &> /dev/null
 
-	echo "::: Server Keys and Pre-Shared Key have been generated."
+	echo "::: Server Keys have been generated."
 
 	echo "[Interface]
 PrivateKey = $($SUDO cat /etc/wireguard/keys/server_priv)

--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -75,6 +75,7 @@ if [ -f "configs/${CLIENT_NAME}.conf" ]; then
 fi
 
 wg genkey | tee "keys/${CLIENT_NAME}_priv" | wg pubkey > "keys/${CLIENT_NAME}_pub"
+CLIENT_PRE_SHARED_KEY=$(wg genpsk)
 echo "::: Client Keys generated"
 
 # Find an unused number for the last octet of the client IP
@@ -102,7 +103,7 @@ echo >> "configs/${CLIENT_NAME}.conf"
 
 echo "[Peer]
 PublicKey = $(cat keys/server_pub)
-PresharedKey = $(cat keys/psk)
+PresharedKey = ${CLIENT_PRE_SHARED_KEY}
 Endpoint = ${pivpnHOST}:${pivpnPORT}
 AllowedIPs = 0.0.0.0/0, ::0/0" >> "configs/${CLIENT_NAME}.conf"
 echo "::: Client config generated"
@@ -110,7 +111,7 @@ echo "::: Client config generated"
 echo "# begin ${CLIENT_NAME}
 [Peer]
 PublicKey = $(cat "keys/${CLIENT_NAME}_pub")
-PresharedKey = $(cat keys/psk)
+PresharedKey = ${CLIENT_PRE_SHARED_KEY}
 AllowedIPs = ${NET_REDUCED}.${COUNT}/32
 # end ${CLIENT_NAME}" >> wg0.conf
 echo "::: Updated server config"

--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -75,7 +75,7 @@ if [ -f "configs/${CLIENT_NAME}.conf" ]; then
 fi
 
 wg genkey | tee "keys/${CLIENT_NAME}_priv" | wg pubkey > "keys/${CLIENT_NAME}_pub"
-CLIENT_PRE_SHARED_KEY=$(wg genpsk)
+wg genpsk | tee "keys/${CLIENT_NAME}_psk" &> /dev/null
 echo "::: Client Keys generated"
 
 # Find an unused number for the last octet of the client IP
@@ -103,7 +103,7 @@ echo >> "configs/${CLIENT_NAME}.conf"
 
 echo "[Peer]
 PublicKey = $(cat keys/server_pub)
-PresharedKey = ${CLIENT_PRE_SHARED_KEY}
+PresharedKey = $(cat "keys/${CLIENT_NAME}_psk")
 Endpoint = ${pivpnHOST}:${pivpnPORT}
 AllowedIPs = 0.0.0.0/0, ::0/0" >> "configs/${CLIENT_NAME}.conf"
 echo "::: Client config generated"
@@ -111,7 +111,7 @@ echo "::: Client config generated"
 echo "# begin ${CLIENT_NAME}
 [Peer]
 PublicKey = $(cat "keys/${CLIENT_NAME}_pub")
-PresharedKey = ${CLIENT_PRE_SHARED_KEY}
+PresharedKey = $(cat "keys/${CLIENT_NAME}_psk")
 AllowedIPs = ${NET_REDUCED}.${COUNT}/32
 # end ${CLIENT_NAME}" >> wg0.conf
 echo "::: Updated server config"

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -91,6 +91,7 @@ for CLIENT_NAME in "${CLIENTS_TO_REMOVE[@]}"; do
 
             rm "keys/${CLIENT_NAME}_priv"
             rm "keys/${CLIENT_NAME}_pub"
+            rm "keys/${CLIENT_NAME}_psk"
             echo "::: Client Keys for ${CLIENT_NAME} removed"
 
             # Find all .conf files in the home folder of the user matching the checksum of the


### PR DESCRIPTION
Generate a unique pre-shared key for each client as per the WireGuard protocol to improve post-quantum resistance.

1. https://www.wireguard.com/papers/wireguard.pdf#subsection.5.2
2. https://wiki.archlinux.org/index.php/WireGuard#Key_generation
3. https://doc.turris.cz/doc/en/public/wireguard