### PR TITLE
Fix spelling & grammar in backup script

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -28,7 +28,7 @@ backup_openvpn(){
     backupzip=$date-pivpnovpnbackup.tgz
     # shellcheck disable=SC2210
     tar czpf "$install_home"/"$backupdir"/"$backupzip" "$openvpndir" "$ovpnsdir" > /dev/null 2>&1
-    echo -e "Backup crated to $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
+    echo -e "Backup created in $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
 
 }
 
@@ -39,7 +39,7 @@ backup_wireguard(){
     checkbackupdir
     backupzip=$date-pivpnwgbackup.tgz
     tar czpf "$install_home"/"$backupdir"/"$backupzip" "$wireguarddir" "$configsdir" > /dev/null 2>&1
-    echo -e "Backup crated to $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
+    echo -e "Backup created in $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
 
 }
 


### PR DESCRIPTION
This will fix #1024.

Changed:

`Backup crated to`

to:

`Backup created in`