### PR TITLE
 Install both Wireguard and Openvpn protocols (Issue #968)

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -35,7 +35,7 @@ backup_openvpn(){
     backupzip=$date-pivpnovpnbackup.tgz
     # shellcheck disable=SC2210
     tar czpf "$install_home"/"$backupdir"/"$backupzip" "$openvpndir" "$ovpnsdir" > /dev/null 2>&1
-    echo -e "Backup crated to $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
+    echo -e "Backup created to $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
 
 }
 
@@ -46,7 +46,8 @@ backup_wireguard(){
     checkbackupdir
     backupzip=$date-pivpnwgbackup.tgz
     tar czpf "$install_home"/"$backupdir"/"$backupzip" "$wireguarddir" "$configsdir" > /dev/null 2>&1
-    echo -e "Backup crated to $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
+    echo -e "Backup cre/
+ated to $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
 
 }
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -2,7 +2,14 @@
 
 backupdir=pivpnbackup
 date=$(date +%Y%m%d-%H%M%S)
-setupVars="/etc/pivpn/setupVars.conf"
+
+# if the variable is set up, says where the config is
+if [ -z $PIVPNCONFIGLOC ]
+then
+  setupVars="/etc/pivpn/setupVars.conf"
+else
+  setupVars="${PIVPNCONFIGLOC}/setupVars.conf"
+fi
 
 if [ ! -f "${setupVars}" ]; then
     echo "::: Missing setup vars file!"
@@ -28,7 +35,7 @@ backup_openvpn(){
     backupzip=$date-pivpnovpnbackup.tgz
     # shellcheck disable=SC2210
     tar czpf "$install_home"/"$backupdir"/"$backupzip" "$openvpndir" "$ovpnsdir" > /dev/null 2>&1
-    echo -e "Backup created in $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
+    echo -e "Backup crated to $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
 
 }
 
@@ -39,7 +46,7 @@ backup_wireguard(){
     checkbackupdir
     backupzip=$date-pivpnwgbackup.tgz
     tar czpf "$install_home"/"$backupdir"/"$backupzip" "$wireguarddir" "$configsdir" > /dev/null 2>&1
-    echo -e "Backup created in $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
+    echo -e "Backup crated to $install_home/$backupdir/$backupzip \nTo restore the backup, follow instructions at:\nhttps://github.com/pivpn/pivpn/wiki/FAQ#how-can-i-migrate-my-configs-to-another-pivpn-instance"
 
 }
 

--- a/scripts/openvpn/makeOVPN.sh
+++ b/scripts/openvpn/makeOVPN.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 # Create OVPN Client
 # Default Variable Declarations
-setupVars="/etc/pivpn/setupVars.conf"
+
+# if the variable is set up, says where the config is
+if [ -z $PIVPNCONFIGLOC ]
+then
+  setupVars="/etc/pivpn/setupVars.conf"
+else
+  setupVars="${PIVPNCONFIGLOC}/setupVars.conf"
+fi
+
 DEFAULT="Default.txt"
 FILEEXT=".ovpn"
 CRT=".crt"
@@ -20,7 +28,7 @@ source "${setupVars}"
 helpFunc() {
     echo "::: Create a client ovpn profile, optional nopass"
     echo ":::"
-    echo "::: Usage: pivpn <-a|add> [-n|--name <arg>] [-p|--password <arg>]|[nopass] [-d|--days <number>] [-b|--bitwarden] [-i|--iOS] [-h|--help]"
+    echo "::: Usage: ${newcommandname} <-a|add> [-n|--name <arg>] [-p|--password <arg>]|[nopass] [-d|--days <number>] [-b|--bitwarden] [-i|--iOS] [-h|--help]"
     echo ":::"
     echo "::: Commands:"
     echo ":::  [none]               Interactive mode"
@@ -188,7 +196,7 @@ function keyPASS() {
         if [[ -z "${PASSWD}" ]]; then
             echo "You left the password blank"
             echo "If you don't want a password, please run:"
-            echo "pivpn add nopass"
+            echo "${newcommandname} add nopass"
             exit 1
         fi
     fi
@@ -426,8 +434,8 @@ for i in {2..254}; do
     fi
 done
 
-if [ -f /etc/pivpn/hosts.openvpn ]; then
-    echo "${NET_REDUCED}.${COUNT} ${NAME}.pivpn" >> /etc/pivpn/hosts.openvpn
+if [ -f ${pivpnetcFilesDir}/hosts.openvpn ]; then
+    echo "${NET_REDUCED}.${COUNT} ${NAME}.pivpn" >> ${pivpnetcFilesDir}/hosts.openvpn
     if killall -SIGHUP pihole-FTL; then
         echo "::: Updated hosts file for Pi-hole"
     else

--- a/scripts/openvpn/pivpn
+++ b/scripts/openvpn/pivpn
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+commandname="$(basename "$(test -L "$0" && readlink "$0" || echo "$0")")"
+PIVPNCONFIGLOC="/etc/${commandname}"
+export PIVPNCONFIGLOC   # will be used by subsequent commands to locate config
+
 # Must be root to use this tool
 if [[ ! $EUID -eq 0 ]];then
   if [[ $(dpkg-query -s sudo) ]];then
@@ -12,24 +16,24 @@ fi
 
 function makeOVPNFunc {
     shift
-    $SUDO /opt/pivpn/makeOVPN.sh "$@"
+    $SUDO -E /opt/${commandname}/makeOVPN.sh "$@"
     exit 0
 }
 
 function listClientsFunc {
     shift
-    $SUDO /opt/pivpn/clientStat.sh "$@"
+    $SUDO /opt/${commandname}/clientStat.sh "$@"
     exit 0
 }
 
 function listOVPNFunc {
-    $SUDO /opt/pivpn/listOVPN.sh
+    $SUDO /opt/${commandname}/listOVPN.sh
     exit 0
 }
 
 function debugFunc {
     echo "::: Generating Debug Output"
-    $SUDO /opt/pivpn/pivpnDebug.sh | tee /tmp/debug.txt
+    $SUDO -E /opt/${commandname}/pivpnDebug.sh | tee /tmp/debug.txt
     echo "::: "
     echo "::: Debug output completed above."
     echo "::: Copy saved to /tmp/debug.txt"
@@ -39,12 +43,12 @@ function debugFunc {
 
 function removeOVPNFunc {
     shift
-    $SUDO /opt/pivpn/removeOVPN.sh "$@"
+    $SUDO -E /opt/${commandname}/removeOVPN.sh "$@"
     exit 0
 }
 
 function uninstallFunc {
-    $SUDO /opt/pivpn/uninstall.sh
+    $SUDO -E /opt/${commandname}/uninstall.sh
     exit 0
 }
 
@@ -55,7 +59,7 @@ function versionFunc {
 function update {
 
     shift
-    $SUDO /opt/pivpn/update.sh "$@"
+    $SUDO -E /opt/${commandname}/update.sh "$@"
     exit 0
 
 
@@ -63,7 +67,7 @@ function update {
 
 function backup {
 
-    $SUDO /opt/pivpn/backup.sh
+    $SUDO -E /opt/${commandname}/backup.sh
     exit 0
 
 }
@@ -72,7 +76,7 @@ function backup {
 function helpFunc {
     echo "::: Control all PiVPN specific functions!"
     echo ":::"
-    echo "::: Usage: pivpn <command> [option]"
+    echo "::: Usage: ${commandname} <command> [option]"
     echo ":::"
     echo "::: Commands:"
     echo ":::  -a, add [nopass]     Create a client ovpn profile, optional nopass"

--- a/scripts/openvpn/pivpnDebug.sh
+++ b/scripts/openvpn/pivpnDebug.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 # This scripts runs as root
 
-setupVars="/etc/pivpn/setupVars.conf"
+# if the variable is set up, says where the config is
+if [ -z $PIVPNCONFIGLOC ]
+then
+  setupVars="/etc/pivpn/setupVars.conf"
+else
+  setupVars="${PIVPNCONFIGLOC}/setupVars.conf"
+fi
 
 if [ ! -f "${setupVars}" ]; then
     echo "::: Missing setup vars file!"
@@ -13,10 +19,10 @@ source "${setupVars}"
 echo -e "::::\t\t\e[4mPiVPN debug\e[0m\t\t ::::"
 printf "=============================================\n"
 echo -e "::::\t\t\e[4mLatest commit\e[0m\t\t ::::"
-git --git-dir /etc/.pivpn/.git log -n 1
+git --git-dir /etc/.${newcommandname}/.git log -n 1
 printf "=============================================\n"
 echo -e "::::\t    \e[4mInstallation settings\e[0m    \t ::::"
-sed "s/$pivpnHOST/REDACTED/" < /etc/pivpn/setupVars.conf
+sed "s/$pivpnHOST/REDACTED/" < ${setupVars}
 printf "=============================================\n"
 echo -e "::::  \e[4mServer configuration shown below\e[0m   ::::"
 cat /etc/openvpn/server.conf
@@ -28,7 +34,7 @@ echo -e ":::: \t\e[4mRecursive list of files in\e[0m\t ::::\n::: \e[4m/etc/openv
 ls -LR /etc/openvpn/easy-rsa/pki/ -Ireqs -Icerts_by_serial
 printf "=============================================\n"
 echo -e "::::\t\t\e[4mSelf check\e[0m\t\t ::::"
-/opt/pivpn/self_check.sh
+${pivpnoptFilesDir}/self_check.sh
 printf "=============================================\n"
 echo -e ":::: Having trouble connecting? Take a look at the FAQ:"
 echo -e ":::: \e[1mhttps://github.com/pivpn/pivpn/wiki/FAQ\e[0m"

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 # PiVPN: revoke client script
 
-setupVars="/etc/pivpn/setupVars.conf"
+# if the variable is set up, says where the config is
+if [ -z $PIVPNCONFIGLOC ]
+then
+  setupVars="/etc/pivpn/setupVars.conf"
+else
+  setupVars="${PIVPNCONFIGLOC}/setupVars.conf"
+fi
+
 INDEX="/etc/openvpn/easy-rsa/pki/index.txt"
 
 if [ ! -f "${setupVars}" ]; then
@@ -14,7 +21,7 @@ source "${setupVars}"
 helpFunc() {
     echo "::: Revoke a client ovpn profile"
     echo ":::"
-    echo "::: Usage: pivpn <-r|revoke> [-h|--help] [<client-1>] ... [<client-n>] ..."
+    echo "::: Usage: ${newcommandname} <-r|revoke> [-h|--help] [<client-1>] ... [<client-n>] ..."
     echo ":::"
     echo "::: Commands:"
     echo ":::  [none]               Interactive mode"

--- a/scripts/self_check.sh
+++ b/scripts/self_check.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-setupVars="/etc/pivpn/setupVars.conf"
+# if the variable is set up, says where the config is
+if [ -z $PIVPNCONFIGLOC ]
+then
+  setupVars="/etc/pivpn/setupVars.conf"
+else
+  setupVars="${PIVPNCONFIGLOC}/setupVars.conf"
+fi
+
 ERR=0
 
 if [ ! -f "${setupVars}" ]; then

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -7,7 +7,14 @@
 PKG_MANAGER="apt-get"
 UPDATE_PKG_CACHE="${PKG_MANAGER} update"
 dnsmasqConfig="/etc/dnsmasq.d/02-pivpn.conf"
-setupVars="/etc/pivpn/setupVars.conf"
+
+# if the variable is set up, says where the config is
+if [ -z $PIVPNCONFIGLOC ]
+then
+  setupVars="/etc/pivpn/setupVars.conf"
+else
+  setupVars="${PIVPNCONFIGLOC}/setupVars.conf"
+fi
 
 if [ ! -f "${setupVars}" ]; then
 	echo "::: Missing setup vars file!"
@@ -152,12 +159,12 @@ removeAll(){
 		pihole restartdns
 	fi
 
-	rm -rf /opt/pivpn
-	rm -rf /etc/.pivpn
-	rm -rf /etc/pivpn
+	rm -rf ${pivpnoptFilesDir}
+	rm -rf ${pivpnetcFilesDir}
+	rm -rf ${setupVars}  # remove only this pivpn setupVars
 	rm -f /var/log/*pivpn*
-	rm -f /usr/local/bin/pivpn
-	rm -f /etc/bash_completion.d/pivpn
+	rm -f ${pivpnlocalbinFilesDir}
+	rm -f /etc/bash_completion.d/${newcommandname}
 
 	echo ":::"
 	echo "::: Removing VPN configuration files..."

--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-setupVars="/etc/pivpn/setupVars.conf"
+# if the variable is set up, says where the config is
+if [ -z $PIVPNCONFIGLOC ]
+then
+  setupVars="/etc/pivpn/setupVars.conf"
+else
+  setupVars="${PIVPNCONFIGLOC}/setupVars.conf"
+fi
 
 if [ ! -f "${setupVars}" ]; then
     echo "::: Missing setup vars file!"

--- a/scripts/wireguard/pivpn
+++ b/scripts/wireguard/pivpn
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+commandname="$(basename "$(test -L "$0" && readlink "$0" || echo "$0")")"
+PIVPNCONFIGLOC="/etc/${commandname}"
+export PIVPNCONFIGLOC   # will be used by subsequent commands to locate config
+
 # Must be root to use this tool
 if [ $EUID -ne 0 ];then
   	if dpkg-query -s sudo &> /dev/null; then
@@ -12,57 +16,57 @@ fi
 
 makeConf(){
     shift
-    $SUDO /opt/pivpn/makeCONF.sh "$@"
+    $SUDO -E /opt/${commandname}/makeCONF.sh "$@"
     exit 0
 }
 
 listConnected(){
     shift
-    $SUDO /opt/pivpn/clientSTAT.sh "$@"
+    $SUDO /opt/${commandname}/clientSTAT.sh "$@"
     exit 0
 }
 
 debug(){
-    $SUDO /opt/pivpn/pivpnDEBUG.sh
+    $SUDO -E /opt/${commandname}/pivpnDEBUG.sh
     exit 0
 }
 
 listClients(){
-    $SUDO /opt/pivpn/listCONF.sh
+    $SUDO /opt/${commandname}/listCONF.sh
     exit 0
 }
 
 showQrcode(){
     shift
-    $SUDO /opt/pivpn/qrcodeCONF.sh "$@"
+    $SUDO /opt/${commandname}/qrcodeCONF.sh "$@"
     exit 0
 }
 
 removeClient(){
     shift
-    $SUDO /opt/pivpn/removeCONF.sh "$@"
+    $SUDO -E /opt/${commandname}/removeCONF.sh "$@"
     exit 0
 }
 
 uninstallServer(){
-    $SUDO /opt/pivpn/uninstall.sh
+    $SUDO -E /opt/${commandname}/uninstall.sh
     exit 0
 }
 
 updateScripts(){
     shift
-    $SUDO /opt/pivpn/update.sh "$@"
+    $SUDO -E /opt/${commandname}/update.sh "$@"
     exit 0
 }
 
 backup(){
-  $SUDO /opt/pivpn/backup.sh
+  $SUDO -E /opt/${commandname}/backup.sh
 }
 
 showHelp(){
     echo "::: Control all PiVPN specific functions!"
     echo ":::"
-    echo "::: Usage: pivpn <command> [option]"
+    echo "::: Usage: ${commandname} <command> [option]"
     echo ":::"
     echo "::: Commands:"
     echo ":::  -a,  add              Create a client conf profile"

--- a/scripts/wireguard/pivpnDEBUG.sh
+++ b/scripts/wireguard/pivpnDEBUG.sh
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 # This scripts runs as root
 
-setupVars="/etc/pivpn/setupVars.conf"
+# if the variable is set up, says where the config is
+if [ -z $PIVPNCONFIGLOC ]
+then
+  setupVars="/etc/pivpn/setupVars.conf"
+else
+  setupVars="${PIVPNCONFIGLOC}/setupVars.conf"
+fi
 
 if [ ! -f "${setupVars}" ]; then
     echo "::: Missing setup vars file!"
@@ -13,10 +19,10 @@ source "${setupVars}"
 echo -e "::::\t\t\e[4mPiVPN debug\e[0m\t\t ::::"
 printf "=============================================\n"
 echo -e "::::\t\t\e[4mLatest commit\e[0m\t\t ::::"
-git --git-dir /etc/.pivpn/.git log -n 1
+git --git-dir /etc/.${newcommandname}/.git log -n 1
 printf "=============================================\n"
 echo -e "::::\t    \e[4mInstallation settings\e[0m    \t ::::"
-sed "s/$pivpnHOST/REDACTED/" < /etc/pivpn/setupVars.conf
+sed "s/$pivpnHOST/REDACTED/" < ${setupVars} 
 printf "=============================================\n"
 echo -e "::::  \e[4mServer configuration shown below\e[0m   ::::"
 cd /etc/wireguard/keys
@@ -46,7 +52,7 @@ echo -e ":::: \t\e[4mRecursive list of files in\e[0m\t ::::\n::::\e\t[4m/etc/wir
 ls -LR /etc/wireguard
 printf "=============================================\n"
 echo -e "::::\t\t\e[4mSelf check\e[0m\t\t ::::"
-/opt/pivpn/self_check.sh
+${pivpnoptFilesDir}/self_check.sh
 printf "=============================================\n"
 echo -e ":::: Having trouble connecting? Take a look at the FAQ:"
 echo -e ":::: \e[1mhttps://github.com/pivpn/pivpn/wiki/FAQ\e[0m"

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-setupVars="/etc/pivpn/setupVars.conf"
+# if the variable is set up, says where the config is
+if [ -z $PIVPNCONFIGLOC ]
+then
+  setupVars="/etc/pivpn/setupVars.conf"
+else
+  setupVars="${PIVPNCONFIGLOC}/setupVars.conf"
+fi
 
 if [ ! -f "${setupVars}" ]; then
     echo "::: Missing setup vars file!"


### PR DESCRIPTION
        Added --altcommand to the installer.
        Allows two installations at once.
        The installations can be removed or updated independently.
        Example bash install.sh --altcommand wg
          then try 'pivpn_wg help'
        Example bash install.sh --altcommand opv
          then try 'pivpn_opv help'
        or if already installed, can install the other VPN protocol as well
        Example bash install.sh
        Example bash install.sh --altcommand opv
        The --altcommand names are not checked against the vpn type

Tested using RasPIW+.  Because not a major use case this has changed the command  for at least one of the protocols.