### PR TITLE
Tidy dual VPN protocol install

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,6 @@
 About
 -----
 
-TS: 20/5/2020 starting change
-
-Modification that allows installing both openvpn and wireguard on the same machine.  To do this, run the installer twice locally, makeing sure you are going to pull branch test.  
-
-
 Visit the [PiVPN](https://pivpn.io) site for more information.
 This is a set of shell scripts initially developed by **@0-kaladin** that serve to easily turn your Raspberry Pi (TM)
 into a VPN server using two free, open-source protocols:
@@ -19,7 +14,7 @@ into a VPN server using two free, open-source protocols:
 Have you been looking for a good guide or tutorial for setting up a VPN server on a Raspberry Pi or Ubuntu based server?  
 Run this script and you don't need a guide or tutorial, this will do it all for you, in a fraction of the time and with hardened security settings in place by default.  
 
-The master branch of this script installs and configures either WireGuard or OpenVPN on Raspbian, Debian or Ubuntu and it as been tested to run not only on Raspberry Pi but also in any Cloud Provider VPS.  
+The master branch of this script installs and configures either WireGuard or OpenVPN (or both) on Raspbian, Debian or Ubuntu and it as been tested to run not only on Raspberry Pi but also in any Cloud Provider VPS.  
 We recommend using the latest Raspbian Lite image on a Raspberry Pi in your home so you can VPN into your home from a unsecure remote locations and safely use the internet.  
 However, the scripts do try to detect different distributions and make adjustments accordingly.  
 They should work on the majority of Ubuntu and Debian based distributions including those using UFW by default instead of raw iptables.  

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 About
 -----
 
+TS: 20/5/2020 starting change
+
 Modification that allows installing both openvpn and wireguard on the same machine.  To do this, run the installer twice locally, makeing sure you are going to pull branch test.  
 
 

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -10,11 +10,11 @@
 # curl -L https://install.pivpn.io | bash
 # Make sure you have `curl` installed
 
-# timestamp 2020/5/24 15:44BST
+# timestamp 2020/5/24 15:53BST
 
 ######## VARIABLES #########
-#pivpnGitUrl="https://github.com/pivpn/pivpn.git"
-pivpnGitUrl="/home/pi/repos/pivpn"
+pivpnGitUrl="https://github.com/pivpn/pivpn.git"
+#pivpnGitUrl="/home/pi/repos/pivpn"
 setupVarsFile="setupVars.conf"
 setupConfigDir="/etc/pivpn" 
 tempsetupVarsFile="/tmp/setupVars.conf"

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -10,11 +10,11 @@
 # curl -L https://install.pivpn.io | bash
 # Make sure you have `curl` installed
 
-# timestamp 2020/5/22 12:30BST
+# timestamp 2020/5/22 17:44BST
 
 ######## VARIABLES #########
-#pivpnGitUrl="https://github.com/pivpn/pivpn.git"
-pivpnGitUrl="/home/pi/repos/pivpn"
+pivpnGitUrl="https://github.com/pivpn/pivpn.git"
+#pivpnGitUrl="/home/pi/repos/pivpn"
 setupVarsFile="setupVars.conf"
 setupConfigDir="/etc/pivpn" 
 tempsetupVarsFile="/tmp/setupVars.conf"

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -10,11 +10,11 @@
 # curl -L https://install.pivpn.io | bash
 # Make sure you have `curl` installed
 
-# timestamp 2020/5/14 15:29BST
+# timestamp 2020/5/22 12:30BST
 
 ######## VARIABLES #########
-pivpnGitUrl="https://github.com/pivpn/pivpn.git"
-#pivpnGitUrl="/home/ubuntu/repos/pivpn"
+#pivpnGitUrl="https://github.com/pivpn/pivpn.git"
+pivpnGitUrl="/home/pi/repos/pivpn"
 setupVarsFile="setupVars.conf"
 setupConfigDir="/etc/pivpn" 
 tempsetupVarsFile="/tmp/setupVars.conf"
@@ -126,9 +126,9 @@ main(){
 
         # see which setup already exists
         if [ -r "${setupConfigDir}/wireguard/${setupVarsFile}" ]; then
-             setupVars="${setupConfigDir}/wireguard/${setupVarsFile}"
+                setupVars="${setupConfigDir}/wireguard/${setupVarsFile}"
         elif [ -r "${setupConfigDir}/openvpn/${setupVarsFile}" ]; then
-             setupVars="${setupConfigDir}/openvpn/${setupVarsFile}"
+                setupVars="${setupConfigDir}/openvpn/${setupVarsFile}"
         fi 
 
 	if [ -r "$setupVars" ]; then 
@@ -244,7 +244,7 @@ askAboutExistingInstall(){
 	opt3a="Reconfigure"
 	opt3b="Reinstall PiVPN with new settings"
 
-	UpdateCmd=$(whiptail --title "Existing Install Detected!" --menu "\nWe have detected an existing install.\n$1\n\nPlease choose from the following options:" ${r} ${c} 3 \
+	UpdateCmd=$(whiptail --title "Existing Install Detected!" --menu "\nWe have detected an existing install.\n$1\n\nPlease choose from the following options (Reconfigure can be used to add a second VPN type):" ${r} ${c} 3 \
 	"${opt1a}"  "${opt1b}" \
 	"${opt2a}"  "${opt2b}" \
 	"${opt3a}"  "${opt3b}" 3>&2 2>&1 1>&3) || \
@@ -2243,31 +2243,34 @@ installScripts(){
 	$SUDO install -m 755 -t ${pivpnScriptDir} ${pivpnFilesDir}/scripts/*.sh  
 	$SUDO install -m 755 -t ${pivpnScriptDir}/${VPN} ${pivpnFilesDir}/scripts/${VPN}/*.sh 
         # make a link for a single command being installed
-        $SUDO ln -s -T ${pivpnScriptDir}/${VPN}/pivpn.sh /usr/local/bin/pivpn
+        # may already exist if installing the second protocol
+        if [ ! -e "/usr/local/bin/pivpn" ]; then
+               $SUDO ln -s -T ${pivpnScriptDir}/${VPN}/pivpn.sh /usr/local/bin/pivpn
+        fi
         # if the other protocol file exists it has been installed
         if [[ ${VPN} == 'wireguard' ]]; then
-           othervpn='openvpn'
+               othervpn='openvpn'
         else
-           othervpn='wireguard'
+               othervpn='wireguard'
         fi
 
         if [ -r "${setupConfigDir}/${othervpn}/${setupVarsFile}" ]; then
-           # both are installed
-           # dont need a link, copy the common script to the location instead
-           $SUDO rm -f /usr/local/bin/pivpn
-	   $SUDO install -m 755 -t /usr/local/bin /${pivpnFilesDir}/scripts/pivpn 
+               # both are installed
+               # dont need a link, copy the common script to the location instead
+               $SUDO rm -f /usr/local/bin/pivpn
+	       $SUDO install -m 755 -t /usr/local/bin /${pivpnFilesDir}/scripts/pivpn 
 	fi
   
         if [ -r "${setupConfigDir}/${othervpn}/${setupVarsFile}" ]; then
-           # both are installed, no bash completion, delete if already there
-           $SUDO rm -f /etc/bash_completion.d/pivpn
+               # both are installed, no bash completion, delete if already there
+               $SUDO rm -f /etc/bash_completion.d/pivpn
 	else
-           # only one protocol is installed, put bash completion in place
-           $SUDO cp "${pivpnFilesDir}/scripts/${VPN}/bash-completion" /etc/bash_completion.d/pivpn
-           $SUDO chown root:root /etc/bash_completion.d/pivpn
-           $SUDO chmod 755 /etc/bash_completion.d/pivpn
-	   # shellcheck disable=SC1091
-	   . /etc/bash_completion.d/pivpn
+               # only one protocol is installed, put bash completion in place
+               $SUDO cp "${pivpnFilesDir}/scripts/${VPN}/bash-completion" /etc/bash_completion.d/pivpn
+               $SUDO chown root:root /etc/bash_completion.d/pivpn
+               $SUDO chmod 755 /etc/bash_completion.d/pivpn
+	       # shellcheck disable=SC1091
+	       . /etc/bash_completion.d/pivpn
         fi
 	echo " done."
 }

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -10,7 +10,7 @@
 # curl -L https://install.pivpn.io | bash
 # Make sure you have `curl` installed
 
-# timestamp 2020/5/22 17:44BST
+# timestamp 2020/5/24 15:44BST
 
 ######## VARIABLES #########
 #pivpnGitUrl="https://github.com/pivpn/pivpn.git"

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -13,8 +13,8 @@
 # timestamp 2020/5/22 17:44BST
 
 ######## VARIABLES #########
-pivpnGitUrl="https://github.com/pivpn/pivpn.git"
-#pivpnGitUrl="/home/pi/repos/pivpn"
+#pivpnGitUrl="https://github.com/pivpn/pivpn.git"
+pivpnGitUrl="/home/pi/repos/pivpn"
 setupVarsFile="setupVars.conf"
 setupConfigDir="/etc/pivpn" 
 tempsetupVarsFile="/tmp/setupVars.conf"

--- a/scripts/openvpn/pivpnDebug.sh
+++ b/scripts/openvpn/pivpnDebug.sh
@@ -28,7 +28,7 @@ echo -e ":::: \t\e[4mRecursive list of files in\e[0m\t ::::\n::: \e[4m/etc/openv
 ls -LR /etc/openvpn/easy-rsa/pki/ -Ireqs -Icerts_by_serial
 printf "=============================================\n"
 echo -e "::::\t\t\e[4mSelf check\e[0m\t\t ::::"
-/opt/pivpn/self_check.sh
+/opt/pivpn/self_check.sh ${VPN}
 printf "=============================================\n"
 echo -e ":::: Having trouble connecting? Take a look at the FAQ:"
 echo -e ":::: \e[1mhttps://github.com/pivpn/pivpn/wiki/FAQ\e[0m"

--- a/scripts/openvpn/pivpnDebug.sh
+++ b/scripts/openvpn/pivpnDebug.sh
@@ -16,7 +16,7 @@ echo -e "::::\t\t\e[4mLatest commit\e[0m\t\t ::::"
 git --git-dir /etc/.pivpn/.git log -n 1
 printf "=============================================\n"
 echo -e "::::\t    \e[4mInstallation settings\e[0m    \t ::::"
-sed "s/$pivpnHOST/REDACTED/" < /etc/pivpn/setupVars.conf
+sed "s/$pivpnHOST/REDACTED/" < ${setupVars}
 printf "=============================================\n"
 echo -e "::::  \e[4mServer configuration shown below\e[0m   ::::"
 cat /etc/openvpn/server.conf

--- a/scripts/pivpn
+++ b/scripts/pivpn
@@ -3,11 +3,11 @@
 # Must be root to use this tool
 if [ $EUID -ne 0 ];then
   	if dpkg-query -s sudo &> /dev/null; then
-        export SUDO="sudo"
+            export SUDO="sudo"
   	else
-    	echo "::: Please install sudo or run this as root."
-    	exit 1
-  fi
+    	    echo "::: Please install sudo or run this as root."
+    	    exit 1
+        fi
 fi
 
 scriptDir="/opt/pivpn"
@@ -17,7 +17,7 @@ showHelp(){
     echo "::: To pass off to the pivpn command for each protocol"
     echo ":::"
     echo "::: Usage: pivpn wg  <command> [option]"
-    echo "::: Usage: pivpn opv <command> [option]"
+    echo "::: Usage: pivpn ovpn <command> [option]"
     echo ":::"
     echo ":::  -h,  help             Show this help dialog"
     exit 0
@@ -30,7 +30,7 @@ fi
 # Handle redirecting to specific functions based on arguments
 case "$1" in
      wg                      ) "${scriptDir}/wireguard/pivpn.sh" "${@:2}";;
-     opv                     ) "${scriptDir}/openvpn/pivpn.sh"   "${@:2}";;
+     ovpn                    ) "${scriptDir}/openvpn/pivpn.sh"   "${@:2}";;
 "-h"  | "help"               ) showHelp;;
 *                            ) showHelp;;
 esac

--- a/scripts/self_check.sh
+++ b/scripts/self_check.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
-runselfcheck()
-{
+# dual protocol, VPN type supplied as $1
+
+setupVars="/etc/pivpn/${VPN}/setupVars.conf"
+ERR=0
+
+if [ ! -f "${setupVars}" ]; then
+	echo "::: Missing setup vars file!"
+	exit 1
+fi
+
 source "${setupVars}"
 
 if [ "$VPN" = "wireguard" ]; then
@@ -156,40 +164,3 @@ fi
 if [ "$ERR" -eq 1 ]; then
 	echo -e "[INFO] Run \e[1mpivpn -d\e[0m again to see if we detect issues"
 fi
-
-} # end function
-
-# now there are two places setupVars.conf can be, so check each one
-
-dualprot='no'
-setupVars="/etc/pivpn/wireguard/setupVars.conf"
-ERR=0
-
-if [ ! -f "${setupVars}" ]; then
-	echo ":::     Missing ${setupVars}i, wireguard not installed"
-else
-        echo ":: [OK] Selfcheck for wireguard, config from ${setupVars}"
-        runselfcheck
-        dualprot='yes'
-fi
-
-setupVars="/etc/pivpn/openvpn/setupVars.conf"
-ERR=0
-
-if [ ! -f "${setupVars}" ]; then
-	echo "::      Missing ${setupVars}, openvpn not installed"
-else
-        echo ":: [OK] Selfcheck for openvpn, config from ${setupVars}"
-        runselfcheck
-        dualprot='yes'
-fi
-
-# add check for a mixed up installation
-setupVars="/etc/pivpn/setupVars.conf"
-
-if [[ ${dualprot} == 'yes' &&  -f "${setupVars}" ]]; then
-	echo ":: [ERR] Older ${setupVars} exists, should not be there,"
-        echo ":: [ERR] two incompatible versions have been installed"
-fi
-
-

--- a/scripts/self_check.sh
+++ b/scripts/self_check.sh
@@ -166,9 +166,9 @@ setupVars="/etc/pivpn/wireguard/setupVars.conf"
 ERR=0
 
 if [ ! -f "${setupVars}" ]; then
-	echo "::: Missing ${setupVars}i, wireguard not installed"
+	echo ":::     Missing ${setupVars}i, wireguard not installed"
 else
-        echo "::: Selfcheck for wireguard, config from ${setupVars}"
+        echo ":: [OK] Selfcheck for wireguard, config from ${setupVars}"
         runselfcheck
         dualprot='yes'
 fi
@@ -177,9 +177,9 @@ setupVars="/etc/pivpn/openvpn/setupVars.conf"
 ERR=0
 
 if [ ! -f "${setupVars}" ]; then
-	echo "::: Missing ${setupVars}, openvpn not installed"
+	echo "::      Missing ${setupVars}, openvpn not installed"
 else
-        echo "::: Selfcheck for openvpn, config from ${setupVars}"
+        echo ":: [OK] Selfcheck for openvpn, config from ${setupVars}"
         runselfcheck
         dualprot='yes'
 fi
@@ -187,9 +187,9 @@ fi
 # add check for a mixed up installation
 setupVars="/etc/pivpn/setupVars.conf"
 
-if [ ${dualprot} == 'yes' &&  -f "${setupVars}" ]; then
-	echo "::: Older ${setupVars} exists, should not be there,
-        echo "::: two versions have been installed which are not compatible"
+if [[ ${dualprot} == 'yes' &&  -f "${setupVars}" ]]; then
+	echo ":: [ERR] Older ${setupVars} exists, should not be there,"
+        echo ":: [ERR] two incompatible versions have been installed"
 fi
 
 

--- a/scripts/self_check.sh
+++ b/scripts/self_check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # dual protocol, VPN type supplied as $1
-
+VPN=$1
 setupVars="/etc/pivpn/${VPN}/setupVars.conf"
 ERR=0
 

--- a/scripts/self_check.sh
+++ b/scripts/self_check.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 
-setupVars="/etc/pivpn/setupVars.conf"
-ERR=0
-
-if [ ! -f "${setupVars}" ]; then
-	echo "::: Missing setup vars file!"
-	exit 1
-fi
-
+runselfcheck()
+{
 source "${setupVars}"
 
 if [ "$VPN" = "wireguard" ]; then
@@ -162,3 +156,40 @@ fi
 if [ "$ERR" -eq 1 ]; then
 	echo -e "[INFO] Run \e[1mpivpn -d\e[0m again to see if we detect issues"
 fi
+
+} # end function
+
+# now there are two places setupVars.conf can be, so check each one
+
+dualprot='no'
+setupVars="/etc/pivpn/wireguard/setupVars.conf"
+ERR=0
+
+if [ ! -f "${setupVars}" ]; then
+	echo "::: Missing ${setupVars}i, wireguard not installed"
+else
+        echo "::: Selfcheck for wireguard, config from ${setupVars}"
+        runselfcheck
+        dualprot='yes'
+fi
+
+setupVars="/etc/pivpn/openvpn/setupVars.conf"
+ERR=0
+
+if [ ! -f "${setupVars}" ]; then
+	echo "::: Missing ${setupVars}, openvpn not installed"
+else
+        echo "::: Selfcheck for openvpn, config from ${setupVars}"
+        runselfcheck
+        dualprot='yes'
+fi
+
+# add check for a mixed up installation
+setupVars="/etc/pivpn/setupVars.conf"
+
+if [ ${dualprot} == 'yes' &&  -f "${setupVars}" ]; then
+	echo "::: Older ${setupVars} exists, should not be there,
+        echo "::: two versions have been installed which are not compatible"
+fi
+
+

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -4,6 +4,24 @@
 ### FIXME: global: config storage, refactor all scripts to adhere to the storage
 ### FIXME: use variables where appropriate, reduce magic numbers by 99.9%, at least.
 
+# what is already installed?
+setupVars="/etc/pivpn/openvpn/setupVars.conf"
+foundins=''
+if [ -f "${setupVars}" ]; then
+        foundins="openvpn"
+fi
+
+setupVars="/etc/pivpn/wireguard/setupVars.conf"
+if [ -f "${setupVars}" ]; then
+        foundins="${foundins} wireguard"
+fi
+
+if [ -z ${foundins} ]; then
+  foundins="nothing found"
+fi
+
+
+
 # Find the rows and columns. Will default to 80x24 if it can not be detected.
 screen_size=$(stty size 2>/dev/null || echo 24 80)
 rows=$(echo "$screen_size" | awk '{print $1}')
@@ -16,7 +34,7 @@ c=$(( columns / 2 ))
 r=$(( r < 20 ? 20 : r ))
 c=$(( c < 70 ? 70 : c ))
 
-                       chooseVPNCmd=(whiptail --backtitle "Setup PiVPN" --title "Installation mode" --separate-output --radiolist "WireGuard is a new kind of VPN that provides near-instantaneous connection speed, high performance, and modern cryptography.\\n\\nIt's the recommended choice especially if you use mobile devices where WireGuard is easier on battery than OpenVPN.\\n\\nOpenVPN is still available if you need the traditional, flexible, trusted VPN protocol or if you need features like TCP and custom search domain.\\n\\nChoose a VPN to uninstall (press space to select):" "${r}" "${c}" 2)
+                       chooseVPNCmd=(whiptail --backtitle "Setup PiVPN" --title "Installation mode" --separate-output --radiolist "WireGuard is a new kind of VPN that provides near-instantaneous connection speed, high performance, and modern cryptography.\\n\\nIt's the recommended choice especially if you use mobile devices where WireGuard is easier on battery than OpenVPN.\\n\\nOpenVPN is still available if you need the traditional, flexible, trusted VPN protocol or if you need features like TCP and custom search domain.\\n\\nChoose a VPN (${foundins}) to uninstall (press space to select):" "${r}" "${c}" 2)
                         VPNChooseOptions=(WireGuard "" on
                                                                 OpenVPN "" off)
 
@@ -108,21 +126,21 @@ removeAll(){
         vpnStillExists='no'
 
         if [ -r "${setupConfigDir}/${othervpn}/${setupVarsFile}" ]; then
-	  vpnStillExists='yes'
-          $SUDO rm -f /usr/local/bin/pivpn
-          $SUDO ln -s -T /opt/pivpn/${othervpn}/pivpn.sh /usr/local/bin/pivpn
-          echo ":::"
-          echo "::: Two VPN protocols exist, you should remove ${othervpn} too"
-          echo ":::"
+	      vpnStillExists='yes'
+              $SUDO rm -f /usr/local/bin/pivpn
+              $SUDO ln -s -T /opt/pivpn/${othervpn}/pivpn.sh /usr/local/bin/pivpn
+              echo ":::"
+              echo "::: Two VPN protocols exist, you should remove ${othervpn} too"
+              echo ":::"
         
         else
-	    rm -f /etc/bash_completion.d/pivpn
+	      rm -f /etc/bash_completion.d/pivpn
         fi
 
 	# Disable IPv4 forwarding
         if [ ${vpnStillExists} == 'no'  ]; then
-	   sed -i '/net.ipv4.ip_forward=1/c\#net.ipv4.ip_forward=1' /etc/sysctl.conf
-	   sysctl -p
+	        sed -i '/net.ipv4.ip_forward=1/c\#net.ipv4.ip_forward=1' /etc/sysctl.conf
+	        sysctl -p
         fi
 
 	# Purge dependencies
@@ -204,18 +222,18 @@ removeAll(){
 	fi
 
         if [ ${vpnStillExists} == 'no'  ]; then
-	   echo ":::"
-	   echo "::: Removing pivpn system files..."
-           rm -rf /etc/.pivpn
-	   rm  -rf /etc/pivpn
-	   rm -f /var/log/*pivpn*
-           rm -rf /opt/pivpn
-           rm -f /usr/local/bin/pivpn
+	        echo ":::"
+	        echo "::: Removing pivpn system files..."
+                rm -rf /etc/.pivpn
+	        rm -rf /etc/pivpn
+	        rm -f /var/log/*pivpn*
+                rm -rf /opt/pivpn
+                rm -f /usr/local/bin/pivpn
         else
-	   echo ":::"
-	   echo "::: Other protocol still present, so not"
-           echo "::: removing pivpn system files"
-           rm -f "${setupConfigDir}/${VPN}/${setupVarsFile}"
+	        echo ":::"
+	        echo "::: Other protocol still present, so not"
+                echo "::: removing pivpn system files"
+                rm -f "${setupConfigDir}/${VPN}/${setupVarsFile}"
         fi
 
 	echo ":::"

--- a/scripts/wireguard/pivpnDEBUG.sh
+++ b/scripts/wireguard/pivpnDEBUG.sh
@@ -46,7 +46,7 @@ echo -e ":::: \t\e[4mRecursive list of files in\e[0m\t ::::\n::::\e\t[4m/etc/wir
 ls -LR /etc/wireguard
 printf "=============================================\n"
 echo -e "::::\t\t\e[4mSelf check\e[0m\t\t ::::"
-/opt/pivpn/self_check.sh
+/opt/pivpn/self_check.sh ${VPN}
 printf "=============================================\n"
 echo -e ":::: Having trouble connecting? Take a look at the FAQ:"
 echo -e ":::: \e[1mhttps://github.com/pivpn/pivpn/wiki/FAQ\e[0m"

--- a/scripts/wireguard/pivpnDEBUG.sh
+++ b/scripts/wireguard/pivpnDEBUG.sh
@@ -16,7 +16,7 @@ echo -e "::::\t\t\e[4mLatest commit\e[0m\t\t ::::"
 git --git-dir /etc/.pivpn/.git log -n 1
 printf "=============================================\n"
 echo -e "::::\t    \e[4mInstallation settings\e[0m    \t ::::"
-sed "s/$pivpnHOST/REDACTED/" < /etc/pivpn/setupVars.conf
+sed "s/$pivpnHOST/REDACTED/" < ${setupVars}
 printf "=============================================\n"
 echo -e "::::  \e[4mServer configuration shown below\e[0m   ::::"
 cd /etc/wireguard/keys


### PR DESCRIPTION
  remove refs to /etc/pivpn/setupVars in selfcheck and debug scripts
  tidy indenting
  on install, check if symlink already exists before making one to avoid error
  uninstall indicates which vpns are available for uninstall
  selfcheck checks both protocols if both present
  install - additional text in reconfigure saying 2nd protocol can be added
  change to use pivpn ovpn insteed of pivpn opv when dual protocols exist
  change to README.md, since dual protocols not a major feature