### PR TITLE
Improved dual VPN uninstallation, remove duplicate code/script

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -999,6 +999,9 @@ getGitFiles(){
 }
 
 cloneOrUpdateRepos(){
+	# /usr/local should always exist, not sure about the src subfolder though
+	$SUDO mkdir -p /usr/local/src
+
 	# Get Git files
 	getGitFiles ${pivpnFilesDir} ${pivpnGitUrl} || \
 	{ echo "!!! Unable to clone ${pivpnGitUrl} into ${pivpnFilesDir}, unable to continue."; \
@@ -2224,6 +2227,9 @@ confUnattendedUpgrades(){
 }
 
 installScripts(){
+	# Ensure /opt exists (issue #607)
+	$SUDO mkdir -p /opt
+
 	if [[ ${VPN} == 'wireguard' ]]; then
 		othervpn='openvpn'
 	else

--- a/scripts/openvpn/pivpn.sh
+++ b/scripts/openvpn/pivpn.sh
@@ -47,30 +47,19 @@ function removeOVPNFunc {
 }
 
 function uninstallFunc {
-    $SUDO ${scriptDir}/uninstall.sh
+    $SUDO ${scriptDir}/uninstall.sh "${vpn}"
     exit 0
-}
-
-function versionFunc {
-    printf "\e[1mVersion 1.9\e[0m\n"
 }
 
 function update {
-
     shift
-    # $SUDO ${scriptDir}/update.sh "$@"
-    echo "::: The updating functionality for PiVPN scripts is temporarily disabled"
-    echo "::: To keep the VPN (and the system) up to date, use 'apt update' and 'apt upgrade'"
+    $SUDO ${scriptDir}/update.sh "$@"
     exit 0
-
-
 }
 
 function backup {
-
     $SUDO ${scriptDir}/backup.sh
     exit 0
-
 }
 
 
@@ -105,7 +94,6 @@ case "$1" in
 "-r" | "revoke"             ) removeOVPNFunc "$@";;
 "-h" | "help"               ) helpFunc;;
 "-u" | "uninstall"          ) uninstallFunc;;
-"-v"                        ) versionFunc;;
 "-up"| "update"             ) update "$@" ;;
 "-bk"| "backup"             ) backup;;
 *                           ) helpFunc;;

--- a/scripts/openvpn/pivpnDebug.sh
+++ b/scripts/openvpn/pivpnDebug.sh
@@ -13,7 +13,7 @@ source "${setupVars}"
 echo -e "::::\t\t\e[4mPiVPN debug\e[0m\t\t ::::"
 printf "=============================================\n"
 echo -e "::::\t\t\e[4mLatest commit\e[0m\t\t ::::"
-git --git-dir /etc/.pivpn/.git log -n 1
+git --git-dir /usr/local/src/pivpn/.git log -n 1
 printf "=============================================\n"
 echo -e "::::\t    \e[4mInstallation settings\e[0m    \t ::::"
 sed "s/$pivpnHOST/REDACTED/" < ${setupVars}

--- a/scripts/pivpn
+++ b/scripts/pivpn
@@ -11,7 +11,11 @@ if [ $EUID -ne 0 ];then
 fi
 
 scriptDir="/opt/pivpn"
-vpn="wireguard"
+
+uninstallServer(){
+    $SUDO ${scriptDir}/uninstall.sh
+    exit 0
+}
 
 showHelp(){
     echo "::: To pass off to the pivpn command for each protocol"
@@ -20,6 +24,7 @@ showHelp(){
     echo "::: Usage: pivpn ovpn <command> [option]"
     echo ":::"
     echo ":::  -h,  help             Show this help dialog"
+    echo ":::  -u,  uninstall        Uninstall pivpn from your system!"
     exit 0
 }
 
@@ -32,5 +37,6 @@ case "$1" in
      wg                      ) "${scriptDir}/wireguard/pivpn.sh" "${@:2}";;
      ovpn                    ) "${scriptDir}/openvpn/pivpn.sh"   "${@:2}";;
 "-h"  | "help"               ) showHelp;;
+"-u"  | "uninstall"          ) uninstallServer;;
 *                            ) showHelp;;
 esac

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -19,6 +19,10 @@ c=$(( columns / 2 ))
 r=$(( r < 20 ? 20 : r ))
 c=$(( c < 70 ? 70 : c ))
 
+echo "::: The updating functionality for PiVPN scripts is temporarily disabled"
+echo "::: To keep the VPN (and the system) up to date, use 'apt update' and 'apt upgrade'"
+exit 0
+
                        chooseVPNCmd=(whiptail --backtitle "Setup PiVPN" --title "Installation mode" --separate-output --radiolist "Choose a VPN to update (press space to select):" "${r}" "${c}" 2)
                         VPNChooseOptions=(WireGuard "" on
                                                                 OpenVPN "" off)

--- a/scripts/wireguard/pivpn.sh
+++ b/scripts/wireguard/pivpn.sh
@@ -48,15 +48,13 @@ removeClient(){
 }
 
 uninstallServer(){
-    $SUDO ${scriptdir}/uninstall.sh
+    $SUDO ${scriptdir}/uninstall.sh "${vpn}"
     exit 0
 }
 
 updateScripts(){
     shift
-    # $SUDO ${scriptdir}/update.sh "$@"
-    echo "::: The updating functionality for PiVPN scripts is temporarily disabled"
-    echo "::: To keep the VPN (and the system) up to date, use 'apt update' and 'apt upgrade'"
+    $SUDO ${scriptdir}/update.sh "$@"
     exit 0
 }
 
@@ -98,7 +96,6 @@ case "$1" in
 "-h"  | "help"               ) showHelp;;
 "-u"  | "uninstall"          ) uninstallServer;;
 "-up" | "update"             ) updateScripts "$@" ;;
-"-wg" | "wgupdate"           ) updateWireGuard ;;
 "-bk" | "backup"             ) backup ;;
 *                            ) showHelp;;
 esac

--- a/scripts/wireguard/pivpnDEBUG.sh
+++ b/scripts/wireguard/pivpnDEBUG.sh
@@ -13,7 +13,7 @@ source "${setupVars}"
 echo -e "::::\t\t\e[4mPiVPN debug\e[0m\t\t ::::"
 printf "=============================================\n"
 echo -e "::::\t\t\e[4mLatest commit\e[0m\t\t ::::"
-git --git-dir /etc/.pivpn/.git log -n 1
+git --git-dir /usr/local/src/pivpn/.git log -n 1
 printf "=============================================\n"
 echo -e "::::\t    \e[4mInstallation settings\e[0m    \t ::::"
 sed "s/$pivpnHOST/REDACTED/" < ${setupVars}


### PR DESCRIPTION
  - Allow using 'pivpn vpn -u' to directly uninstall VPN 'vpn'
  - Also allow using 'pivpn -u' with two VPNs (will present a dialog).
  - During uninstall, ask which VPN to remove only if there are two VPNs
  - PiVPN git repo will be downloaded to '/usr/local/src/pivpn'. All scripts
    in /opt/pivpn, the main pivpn script and the bash completion file,
    are now just symbolic links. Resolves issue #695.
  - Remove unused call to updateWireGuard().

@shelleycat485 what to you think?