### PR TITLE
Feature: Add Index based option for remove/qr commands

### DIFF
--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -52,22 +52,32 @@ if [[ -z "${CERTS_TO_REVOKE}" ]]; then
         STATUS=$(echo "$line" | awk '{print $1}')
         if [[ "${STATUS}" = "V" ]]; then
             NAME=$(echo "$line" | sed -e 's:.*/CN=::')
-            CERTS[$i]=${NAME}
             if [ "$i" != 0 ]; then
                 # Prevent printing "server" certificate
-                printf "  %s\n" "$NAME"
+                CERTS[$i]=${NAME}
             fi
             let i=i+1
         fi
     done <${INDEX}
+    
+    i=1
+    len=${#CERTS[@]}
+    while [ $i -le ${len} ]; do
+        printf "[%0${#len}s] %s\r\n" ${i} ${CERTS[(($i))]}
+        ((i++))
+    done    
     printf "\n"
 
-    echo -n "::: Please enter the Name of the client to be revoked from the list above: "
+    echo -n "::: Please enter the Index/Name of the client to be revoked from the list above: "
     read -r NAME
 
     if [[ -z "${NAME}" ]]; then
         echo "You can not leave this blank!"
         exit 1
+    fi
+
+    if [[ ${NAME} =~ $re ]] ; then
+        NAME=${CERTS[$(($NAME))]}
     fi
 
     for((x=1;x<=i;++x)); do

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -63,7 +63,7 @@ if [[ -z "${CERTS_TO_REVOKE}" ]]; then
     i=1
     len=${#CERTS[@]}
     while [ $i -le ${len} ]; do
-        printf "[%0${#len}s] %s\r\n" ${i} ${CERTS[(($i))]}
+        printf "%0${#len}s) %s\r\n" ${i} ${CERTS[(($i))]}
         ((i++))
     done    
     printf "\n"

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -76,6 +76,7 @@ if [[ -z "${CERTS_TO_REVOKE}" ]]; then
         exit 1
     fi
 
+    re='^[0-9]+$'
     if [[ ${NAME} =~ $re ]] ; then
         NAME=${CERTS[$(($NAME))]}
     fi

--- a/scripts/wireguard/qrcodeCONF.sh
+++ b/scripts/wireguard/qrcodeCONF.sh
@@ -40,7 +40,7 @@ if [ "${#CLIENTS_TO_SHOW[@]}" -eq 0 ]; then
     len=${#LIST[@]}
     COUNTER=1
     while [ $COUNTER -le ${len} ]; do
-        printf "• [%0${#len}s] %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
+        printf "[%0${#len}s] %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
         ((COUNTER++))
     done
 

--- a/scripts/wireguard/qrcodeCONF.sh
+++ b/scripts/wireguard/qrcodeCONF.sh
@@ -40,7 +40,7 @@ if [ "${#CLIENTS_TO_SHOW[@]}" -eq 0 ]; then
     len=${#LIST[@]}
     COUNTER=1
     while [ $COUNTER -le ${len} ]; do
-        printf "[%0${#len}s] %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
+        printf "%0${#len}s) %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
         ((COUNTER++))
     done
 

--- a/scripts/wireguard/qrcodeCONF.sh
+++ b/scripts/wireguard/qrcodeCONF.sh
@@ -33,17 +33,18 @@ if [ ! -s clients.txt ]; then
     exit 1
 fi
 
+LIST=($(awk '{print $1}' clients.txt))
 if [ "${#CLIENTS_TO_SHOW[@]}" -eq 0 ]; then
 
     echo -e "::\e[4m  Client list  \e[0m::"
-    LIST=($(awk '{print $1}' clients.txt))
+    len=${#LIST[@]}
     COUNTER=1
-    while [ $COUNTER -le ${#LIST[@]} ]; do
-        echo "• ${LIST[(($COUNTER-1))]}"
+    while [ $COUNTER -le ${len} ]; do
+        printf "• [%0${#len}s] %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
         ((COUNTER++))
     done
 
-    read -r -p "Please enter the Name of the Client to show: " CLIENTS_TO_SHOW
+    read -r -p "Please enter the Index/Name of the Client to show: " CLIENTS_TO_SHOW
 
     if [ -z "${CLIENTS_TO_SHOW}" ]; then
         echo "::: You can not leave this blank!"
@@ -52,6 +53,10 @@ if [ "${#CLIENTS_TO_SHOW[@]}" -eq 0 ]; then
 fi
 
 for CLIENT_NAME in "${CLIENTS_TO_SHOW[@]}"; do
+    re='^[0-9]+$'
+    if [[ ${CLIENT_NAME} =~ $re ]] ; then
+        CLIENT_NAME=${LIST[$(($CLIENT_NAME -1))]}
+    fi    
     if grep -qw "${CLIENT_NAME}" clients.txt; then
         echo -e "::: Showing client \e[1m${CLIENT_NAME}\e[0m below"
         echo "====================================================================="

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -48,7 +48,7 @@ if [ "${#CLIENTS_TO_REMOVE[@]}" -eq 0 ]; then
     len=${#LIST[@]}
     COUNTER=1
     while [ $COUNTER -le ${len} ]; do
-        printf "• [%0${#len}s] %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
+        printf "[%0${#len}s] %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
         ((COUNTER++))
     done
 

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -42,17 +42,17 @@ if [ ! -s configs/clients.txt ]; then
     exit 1
 fi
 
+LIST=($(awk '{print $1}' configs/clients.txt))
 if [ "${#CLIENTS_TO_REMOVE[@]}" -eq 0 ]; then
-
     echo -e "::\e[4m  Client list  \e[0m::"
-    LIST=($(awk '{print $1}' configs/clients.txt))
+    len=${#LIST[@]}
     COUNTER=1
-    while [ $COUNTER -le ${#LIST[@]} ]; do
-        echo "• ${LIST[(($COUNTER-1))]}"
+    while [ $COUNTER -le ${len} ]; do
+        printf "• [%0${#len}s] %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
         ((COUNTER++))
     done
 
-    read -r -p "Please enter the Name of the Client to be removed from the list above: " CLIENTS_TO_REMOVE
+    read -r -p "Please enter the Index/Name of the Client to be removed from the list above: " CLIENTS_TO_REMOVE
 
     if [ -z "${CLIENTS_TO_REMOVE}" ]; then
         echo "::: You can not leave this blank!"
@@ -63,6 +63,11 @@ fi
 DELETED_COUNT=0
 
 for CLIENT_NAME in "${CLIENTS_TO_REMOVE[@]}"; do
+
+    re='^[0-9]+$'
+    if [[ ${CLIENT_NAME} =~ $re ]] ; then
+        CLIENT_NAME=${LIST[$(($CLIENT_NAME -1))]}
+    fi
 
     if ! grep -q "^${CLIENT_NAME} " configs/clients.txt; then
         echo -e "::: \e[1m${CLIENT_NAME}\e[0m does not exist"

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -48,7 +48,7 @@ if [ "${#CLIENTS_TO_REMOVE[@]}" -eq 0 ]; then
     len=${#LIST[@]}
     COUNTER=1
     while [ $COUNTER -le ${len} ]; do
-        printf "[%0${#len}s] %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
+        printf "%0${#len}s) %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
         ((COUNTER++))
     done
 


### PR DESCRIPTION
As we could have many client profiles, each with complex names, I thought it would be great if we could also enter a Index value instead of the profile name for the QR code display and delete option

For example:

:: Client list ::
• [1] HomeRob
• [2] HomeRobMobile
• ....
Please enter the Index/Name of the Client to show:

Where the user can either enter '2', or 'HomeRobMobile

This PR has been tested with OpenVPN/remove and WireGuard remove/qr commands

Previous version displayed a middle-dot at the beginning of each line, but i noticed a printing issue in one of my test systems and decided to remove it.
(It looked better with the dot)

https://github.com/pivpn/pivpn/issues/1086
