### PR TITLE
Delete profile and add option to delete private key

### DIFF
--- a/scripts/openvpn/listOVPN.sh
+++ b/scripts/openvpn/listOVPN.sh
@@ -16,7 +16,7 @@ printf "\\e[4mStatus\\e[0m  \t  \\e[4mName\\e[0m\\e[0m  \t  \\e[4mExpiration\\e[
 
 while read -r line || [ -n "$line" ]; do
     STATUS=$(echo "$line" | awk '{print $1}')
-    NAME=$(echo "$line" | awk '{print $5}' | awk -FCN= '{print $2}')
+    NAME=$(echo "$line" | awk -FCN= '{print $2}')
     EXPD=$(echo "$line" | awk '{if (length($2) == 15) print $2; else print "20"$2}' | cut -b 1-8 | date +"%b %d %Y" -f -)
         
     if [ "${STATUS}" == "V" ]; then

--- a/scripts/openvpn/makeOVPN.sh
+++ b/scripts/openvpn/makeOVPN.sh
@@ -34,6 +34,20 @@ helpFunc() {
     echo ":::  -h,--help            Show this help dialog"
 }
 
+safeDelete() {
+    if [ -z "$1" ]; then
+        exit
+    fi
+    if [ ! -f "$1" ]; then
+        exit
+    fi
+    if command -v debconf-apt-progress > /dev/null; then
+        shred -zu -n 35 "$1"
+    else
+        rm "$1"
+    fi
+}
+
 if [ -z "$HELP_SHOWN" ]; then
     helpFunc
     echo
@@ -449,6 +463,11 @@ cp "/etc/openvpn/easy-rsa/pki/$NAME$FILEEXT" "$install_home/ovpns/$NAME$FILEEXT"
 chown "$install_user":"$install_user" "$install_home/ovpns/$NAME$FILEEXT"
 chmod 640 "/etc/openvpn/easy-rsa/pki/$NAME$FILEEXT"
 chmod 640 "$install_home/ovpns/$NAME$FILEEXT"
+
+#cleanup files
+safeDelete "/etc/openvpn/easy-rsa/pki/private/${NAME}${KEY}"
+safeDelete "/etc/openvpn/easy-rsa/pki/${NAME}${FILEEXT}"
+
 printf "\n\n"
 printf "========================================================\n"
 printf "\e[1mDone! %s successfully created!\e[0m \n" "$NAME$FILEEXT"


### PR DESCRIPTION
Remove the local copy of the profile.
Add option -r | --remove to delete private key (after that the option -ovpn will not be possible)

Why deleting these files :
- The profile can be regenerated anytime with -o option, so the file is not useful
- Delete private key is a good security practice
-- If you lost an .ovpn profile, it is a better security practice to revoke it and generate a new than use it again
- Low disk usage (but those few kBs aren't relevant)