### PR TITLE
Handles special characters better

### DIFF
--- a/scripts/openvpn/listOVPN.sh
+++ b/scripts/openvpn/listOVPN.sh
@@ -20,11 +20,11 @@ while read -r line || [ -n "$line" ]; do
     EXPD=$(echo "$line" | awk '{if (length($2) == 15) print $2; else print "20"$2}' | cut -b 1-8 | date +"%b %d %Y" -f -)
         
     if [ "${STATUS}" == "V" ]; then
-        printf "Valid  \t  %s  \t  %s\\n" "$NAME" "$EXPD"
+        printf "Valid  \t  %s  \t  %s\\n" "$(echo -e "$NAME")" "$EXPD"
     elif [ "${STATUS}" == "R" ]; then
-        printf "Revoked  \t  %s  \t  %s\\n" "$NAME" "$EXPD"
+        printf "Revoked  \t  %s  \t  %s\\n" "$(echo -e "$NAME")" "$EXPD"
     else
-        printf "Unknown  \t  %s  \t  %s\\n" "$NAME" "$EXPD"
+        printf "Unknown  \t  %s  \t  %s\\n" "$(echo -e "$NAME")" "$EXPD"
     fi
 
 done <${INDEX}

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -58,7 +58,7 @@ if [[ -z "${CERTS_TO_REVOKE}" ]]; then
             NAME=$(echo "$line" | sed -e 's:.*/CN=::')
             if [ "$i" != 0 ]; then
                 # Prevent printing "server" certificate
-                CERTS[$i]=${NAME}
+                CERTS[$i]=$(echo -e "${NAME}")
             fi
             let i=i+1
         fi
@@ -102,7 +102,7 @@ else
     while read -r line || [ -n "$line" ]; do
         STATUS=$(echo "$line" | awk '{print $1}')
         if [[ "${STATUS}" = "V" ]]; then
-            NAME=$(echo "$line" | sed -e 's:.*/CN=::')
+            NAME=$(echo -e "$line" | sed -e 's:.*/CN=::')
             CERTS[$i]=${NAME}
             let i=i+1
         fi


### PR DESCRIPTION
These changes allow PiVPN scripts to display and revoke certificates with common names like "José" better.  Prior to this commit, names like "José" would be shown as "Jos\xC3\xA9".