### PR TITLE
use wg syncconf

### DIFF
--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -131,9 +131,9 @@ if [ -f /etc/pivpn/hosts.wireguard ]; then
 fi
 
 if wg synnconf wg0 <(wg-quick strip wg0); then
-    echo "::: WireGuard restarted"
+    echo "::: WireGuard reloaded"
 else
-    echo "::: Failed to restart WireGuard"
+    echo "::: Failed to reload WireGuard"
 fi
 
 cp "configs/${CLIENT_NAME}.conf" "${install_home}/configs/${CLIENT_NAME}.conf"

--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -130,7 +130,7 @@ if [ -f /etc/pivpn/hosts.wireguard ]; then
     fi
 fi
 
-if systemctl restart wg-quick@wg0; then
+if wg synnconf wg0 <(wg-quick strip wg0); then
     echo "::: WireGuard restarted"
 else
     echo "::: Failed to restart WireGuard"

--- a/scripts/wireguard/pivpn.sh
+++ b/scripts/wireguard/pivpn.sh
@@ -63,6 +63,11 @@ backup(){
     exit 0
 }
 
+restart(){
+    $SUDO ${scriptdir}/${vpn}/restart.sh
+    exit 0
+}
+
 showHelp(){
     echo "::: Control all PiVPN specific functions!"
     echo ":::"
@@ -79,6 +84,7 @@ showHelp(){
     echo ":::  -u,  uninstall        Uninstall pivpn from your system!"
     echo ":::  -up, update           Updates PiVPN Scripts"
     echo ":::  -bk, backup           Backup VPN configs and user profiles"
+    echo ":::  -rs, restart          Restart Wireguard"
     exit 0
 }
 

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -136,9 +136,9 @@ done
 
 # Restart WireGuard only if some clients were actually deleted
 if [ "${DELETED_COUNT}" -gt 0 ]; then
-    if systemctl restart wg-quick@wg0; then
-        echo "::: WireGuard restarted"
+    if wg syncconf wg0 <(wg-quick strip wg0); then
+        echo "::: WireGuard reloaded"
     else
-        echo "::: Failed to restart WireGuard"
+        echo "::: Failed to reload WireGuard"
     fi
 fi

--- a/scripts/wireguard/restart.sh
+++ b/scripts/wireguard/restart.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+
+if systemctl restart wg-quick@wg0; then
+    echo "::: WireGuard restarted"
+else
+    echo "::: Failed to restart WireGuard"
+fi


### PR DESCRIPTION
thank you for your amazing pivpn project. i just read documentationon wg man page, and i found how to reload wg configuration without interrupt existing connection. by change systemctl restart wg-quick@wg0 to wg syncconfig wg0 <(wg-quick strip wg0). i already implement this on my server and works like charm, and i add another option to manual restart wireguard. thank you



