### PR TITLE
Adding temporary Disable and Enable wireguard clients

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -13,8 +13,8 @@
 # timestamp 2020/5/24 15:53BST
 
 ######## VARIABLES #########
-pivpnGitUrl="https://github.com/pivpn/pivpn.git"
-#pivpnGitUrl="/home/pi/repos/pivpn"
+#pivpnGitUrl="https://github.com/pivpn/pivpn.git"
+pivpnGitUrl="/home/pi/repos/pivpn"
 setupVarsFile="setupVars.conf"
 setupConfigDir="/etc/pivpn"
 tempsetupVarsFile="/tmp/setupVars.conf"

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -13,8 +13,8 @@
 # timestamp 2020/5/24 15:53BST
 
 ######## VARIABLES #########
-#pivpnGitUrl="https://github.com/pivpn/pivpn.git"
-pivpnGitUrl="/home/pi/repos/pivpn"
+pivpnGitUrl="https://github.com/pivpn/pivpn.git"
+#pivpnGitUrl="/home/pi/repos/pivpn"
 setupVarsFile="setupVars.conf"
 setupConfigDir="/etc/pivpn"
 tempsetupVarsFile="/tmp/setupVars.conf"

--- a/scripts/wireguard/bash-completion
+++ b/scripts/wireguard/bash-completion
@@ -4,8 +4,8 @@ _pivpn()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    dashopts="-a -c -d -l -qr -r -h -u -up -bk"
-    opts="add clients debug list qrcode remove help uninstall update backup"
+    dashopts="-a -c -d -l -qr -r -h -u -up -bk -dis -ena"
+    opts="add clients debug list qrcode remove help uninstall update backup disable enable"
     if [ "${#COMP_WORDS[@]}" -eq 2 ]
     then
         if [[ ${cur} == -* ]] ; then

--- a/scripts/wireguard/disableCONF.sh
+++ b/scripts/wireguard/disableCONF.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+setupVars="/etc/pivpn/wireguard/setupVars.conf"
+
+if [ ! -f "${setupVars}" ]; then
+    echo "::: Missing setup vars file!"
+    exit 1
+fi
+
+source "${setupVars}"
+
+helpFunc(){
+    echo "::: Disable client conf profiles"
+    echo ":::"
+    echo "::: Usage: pivpn <-dis|disable> [-h|--help] [-v] [<client-1> ... [<client-2>] ...] "
+    echo ":::"
+    echo "::: Commands:"
+    echo ":::  [none]               Interactive mode"
+    echo ":::  <client>             Client"
+    echo ":::  -y,--yes             Disable client(s) without confirmation"
+    echo ":::  -v                   Show disabled clients only"
+    echo ":::  -h,--help            Show this help dialog"
+}
+
+# Parse input arguments
+while test $# -gt 0
+do
+    _key="$1"
+    case "$_key" in
+        -h|--help)
+            helpFunc
+            exit 0
+            ;;
+        -y|--yes)
+            CONFIRM=true
+            ;;
+        -v)
+            DISPLAY_DISABLED=true
+            ;;
+	*)
+            CLIENTS_TO_CHANGE+=("$1")
+            ;;
+    esac
+    shift
+done
+
+cd /etc/wireguard
+if [ ! -s configs/clients.txt ]; then
+    echo "::: There are no clients to remove"
+    exit 1
+fi
+
+
+if [ "$DISPLAY_DISABLED" ]; then
+    grep 'disabled### begin client' wg0.conf | sed 's/#//g; s/begin//'
+    exit 1
+fi
+
+
+LIST=($(awk '{print $1}' configs/clients.txt))
+if [ "${#CLIENTS_TO_CHANGE[@]}" -eq 0 ]; then
+    echo -e "::\e[4m  Client list  \e[0m::"
+    len=${#LIST[@]}
+    COUNTER=1
+    while [ $COUNTER -le ${len} ]; do
+        printf "%0${#len}s) %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
+        ((COUNTER++))
+    done
+
+    read -r -p "Please enter the Index/Name of the Client to be removed from the list above: " CLIENTS_TO_CHANGE
+
+    if [ -z "${CLIENTS_TO_CHANGE}" ]; then
+        echo "::: You can not leave this blank!"
+        exit 1
+    fi
+fi
+
+CHANGED_COUNT=0
+
+for CLIENT_NAME in "${CLIENTS_TO_CHANGE[@]}"; do
+
+    re='^[0-9]+$'
+    if [[ ${CLIENT_NAME} =~ $re ]] ; then
+        CLIENT_NAME=${LIST[$(($CLIENT_NAME -1))]}
+    fi
+
+    if ! grep -q "^${CLIENT_NAME} " configs/clients.txt; then
+        echo -e "::: \e[1m${CLIENT_NAME}\e[0m does not exist"
+    elif grep -q "#disabled### begin ${CLIENT_NAME}" wg0.conf; then
+        echo -e "::: \e[1m${CLIENT_NAME}\e[0m is already disabled"
+    else
+        if [ -n "$CONFIRM" ]; then
+            REPLY="y"
+        else
+            read -r -p "Confirm you want to disable $CLIENT_NAME? [Y/n] "
+        fi
+
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+
+            # Disable the peer section from the server config
+	    echo "${CLIENT_NAME}"
+            sed -e "/### begin ${CLIENT_NAME}/,/end ${CLIENT_NAME}/ s/^/#disabled/" -i wg0.conf
+            echo "::: Updated server config"
+
+            ((CHANGED_COUNT++))
+            echo "::: Successfully disabled ${CLIENT_NAME}"
+
+        fi
+    fi
+
+done
+
+# Restart WireGuard only if some clients were actually deleted
+if [ "${CHANGED_COUNT}" -gt 0 ]; then
+    if systemctl reload wg-quick@wg0; then
+        echo "::: WireGuard reloaded"
+    else
+        echo "::: Failed to reload WireGuard"
+    fi
+fi

--- a/scripts/wireguard/enableCONF.sh
+++ b/scripts/wireguard/enableCONF.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+setupVars="/etc/pivpn/wireguard/setupVars.conf"
+
+if [ ! -f "${setupVars}" ]; then
+    echo "::: Missing setup vars file!"
+    exit 1
+fi
+
+source "${setupVars}"
+
+helpFunc(){
+    echo "::: Enables client conf profiles"
+    echo ":::"
+    echo "::: Usage: pivpn <-ena|enable> [-h|--help] [-v] [<client-1> ... [<client-2>] ...] "
+    echo ":::"
+    echo "::: Commands:"
+    echo ":::  [none]               Interactive mode"
+    echo ":::  <client>             Client"
+    echo ":::  -y,--yes             Remove client(s) without confirmation"
+    echo ":::  -v                   Show disabled clients only"
+    echo ":::  -h,--help            Show this help dialog"
+}
+
+# Parse input arguments
+while test $# -gt 0
+do
+    _key="$1"
+    case "$_key" in
+        -h|--help)
+            helpFunc
+            exit 0
+            ;;
+        -y|--yes)
+            CONFIRM=true
+            ;;
+        -v)
+            DISPLAY_DISABLED=true
+            ;;
+	*)
+            CLIENTS_TO_CHANGE+=("$1")
+            ;;
+    esac
+    shift
+done
+
+cd /etc/wireguard
+if [ ! -s configs/clients.txt ]; then
+    echo "::: There are no clients to change"
+    exit 1
+fi
+
+if [ "$DISPLAY_DISABLED" ]; then
+    grep 'disabled### begin client' wg0.conf | sed 's/#//g; s/begin//'
+    exit 1
+fi
+
+LIST=($(awk '{print $1}' configs/clients.txt))
+if [ "${#CLIENTS_TO_CHANGE[@]}" -eq 0 ]; then
+    echo -e "::\e[4m  Client list  \e[0m::"
+    len=${#LIST[@]}
+    COUNTER=1
+    while [ $COUNTER -le ${len} ]; do
+        printf "%0${#len}s) %s\r\n" ${COUNTER} ${LIST[(($COUNTER-1))]}
+        ((COUNTER++))
+    done
+
+    read -r -p "Please enter the Index/Name of the Client to be enabled from the list above: " CLIENTS_TO_CHANGE
+
+    if [ -z "${CLIENTS_TO_CHANGE}" ]; then
+        echo "::: You can not leave this blank!"
+        exit 1
+    fi
+fi
+
+CHANGED_COUNT=0
+
+for CLIENT_NAME in "${CLIENTS_TO_CHANGE[@]}"; do
+
+    re='^[0-9]+$'
+    if [[ ${CLIENT_NAME} =~ $re ]] ; then
+        CLIENT_NAME=${LIST[$(($CLIENT_NAME -1))]}
+    fi
+
+    if ! grep -q "^${CLIENT_NAME} " configs/clients.txt; then
+        echo -e "::: \e[1m${CLIENT_NAME}\e[0m does not exist"
+    else
+        if [ -n "$CONFIRM" ]; then
+            REPLY="y"
+        else
+            read -r -p "Confirm you want to enable $CLIENT_NAME? [Y/n] "
+        fi
+
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+
+            # Enable the peer section from the server config
+	    echo "${CLIENT_NAME}" 
+            sed -e "/begin ${CLIENT_NAME}/,/end ${CLIENT_NAME}/ s/#disabled//" -i wg0.conf
+            echo "::: Updated server config"
+
+            ((CHANGED_COUNT++))
+            echo "::: Successfully enabled ${CLIENT_NAME}"
+
+        fi
+    fi
+
+done
+
+# Restart WireGuard only if some clients were actually deleted
+if [ "${CHANGED_COUNT}" -gt 0 ]; then
+    if systemctl reload wg-quick@wg0; then
+        echo "::: WireGuard reloaded"
+    else
+        echo "::: Failed to reload WireGuard"
+    fi
+fi

--- a/scripts/wireguard/enableCONF.sh
+++ b/scripts/wireguard/enableCONF.sh
@@ -17,7 +17,7 @@ helpFunc(){
     echo "::: Commands:"
     echo ":::  [none]               Interactive mode"
     echo ":::  <client>             Client"
-    echo ":::  -y,--yes             Remove client(s) without confirmation"
+    echo ":::  -y,--yes             Enable client(s) without confirmation"
     echo ":::  -v                   Show disabled clients only"
     echo ":::  -h,--help            Show this help dialog"
 }

--- a/scripts/wireguard/listCONF.sh
+++ b/scripts/wireguard/listCONF.sh
@@ -26,3 +26,8 @@ while read -r LINE; do
 done < clients.txt
 
 } | column -t -s $'\t'
+
+
+cd /etc/wireguard || return
+echo "::: Disabled clients :::"
+grep 'disabled### begin client' wg0.conf | sed 's/#//g; s/begin//'

--- a/scripts/wireguard/pivpn.sh
+++ b/scripts/wireguard/pivpn.sh
@@ -47,6 +47,18 @@ removeClient(){
     exit 0
 }
 
+disableClient(){
+    shift
+    $SUDO ${scriptdir}/${vpn}/disableCONF.sh "$@"
+    exit 0
+}
+
+enableClient(){
+    shift
+    $SUDO ${scriptdir}/${vpn}/enableCONF.sh "$@"
+    exit 0
+}
+
 uninstallServer(){
     $SUDO ${scriptdir}/uninstall.sh "${vpn}"
     exit 0
@@ -75,6 +87,8 @@ showHelp(){
     echo ":::  -l,  list             List all clients"
     echo ":::  -qr, qrcode           Show the qrcode of a client for use with the mobile app"
     echo ":::  -r,  remove           Remove a client"
+    echo ":::  -dis,  disable        Disable a user"
+    echo ":::  -ena,  enable         Enable a user"
     echo ":::  -h,  help             Show this help dialog"
     echo ":::  -u,  uninstall        Uninstall pivpn from your system!"
     echo ":::  -up, update           Updates PiVPN Scripts"
@@ -88,15 +102,17 @@ fi
 
 # Handle redirecting to specific functions based on arguments
 case "$1" in
-"-a"  | "add"                ) makeConf "$@";;
-"-c"  | "clients"            ) listConnected "$@";;
-"-d"  | "debug"              ) debug;;
-"-l"  | "list"               ) listClients;;
-"-qr" | "qrcode"             ) showQrcode "$@";;
-"-r"  | "remove"             ) removeClient "$@";;
-"-h"  | "help"               ) showHelp;;
-"-u"  | "uninstall"          ) uninstallServer;;
-"-up" | "update"             ) updateScripts "$@" ;;
-"-bk" | "backup"             ) backup ;;
+"-a"   | "add"                ) makeConf "$@";;
+"-c"   | "clients"            ) listConnected "$@";;
+"-d"   | "debug"              ) debug;;
+"-l"   | "list"               ) listClients;;
+"-qr"  | "qrcode"             ) showQrcode "$@";;
+"-r"   | "remove"             ) removeClient "$@";;
+"-dis" | "disable"            ) disableClient "$@";;
+"-ena" | "enable"             ) enableClient "$@";;
+"-h"   | "help"               ) showHelp;;
+"-u"   | "uninstall"          ) uninstallServer;;
+"-up"  | "update"             ) updateScripts "$@" ;;
+"-bk"  | "backup"             ) backup ;;
 *                            ) showHelp;;
 esac


### PR DESCRIPTION
Adds pivpn disable or -dis, and pivpn enable -ena.  This disables or re-enables an existing wireguard client.   pivpn -dis -v will show which clients are disabled.  pivpn -ena -v also show which clients are disabled.   Also pivpn -l will indicate if any clients are disabled.  This is implemented by changing the wg0.conf file only, no other configuration files are changed.

Testing of disable followed by disable and enable followed by enable and on non-existent clients seem OK.
Disabled clients can be removed. A pivpn add does not work if a disabled client with the same name exists. 
At this moment this does not work on AWS ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-* because the wireguard service cannot be reloaded (see pull request #1164 ).  It has been otherwise tested on that machine, and on a RPi4, Buster.  Addresses issue #1111.