### PR TITLE
Fixed status command (echo) in isRepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![WireGuard + OpenVPN logo](logos.jpg)
 
-**[Is pivpn.io down?](https://p.datadoghq.com/sb/od1t7p4rmqi6x1fm-cd513e61b0eb77a5d5f6a52fe0662205?theme=dark)**
+**[Is pivpn.io down?](https://status.pivpn.io)**
 
 About
 -----

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -991,7 +991,7 @@ chooseUser(){
 isRepo(){
 	# If the directory does not have a .git folder it is not a repo
 	echo -n ":::    Checking $1 is a repo..."
-	cd "${1}" &> /dev/null || return 1
+	cd "${1}" &> /dev/null || { echo " not found!"; return 1 }
 	$SUDO git status &> /dev/null && echo " OK!"; return 0 || echo " not found!"; return 1
 }
 


### PR DESCRIPTION
The status reported by `isRepo` fails to print a new line when the directory is not a git repo, because the function returns without printing the conclusion of the checks in one of the possible situations. This fixes this small visual bug. I don't know if the printed messages is the most suitable, but it now includes a new line.