### PR TITLE
Wording and exit code for wireguard remove script

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,17 @@
+daysUntilStale: 15
+daysUntilClose: 7
+exemptLabels:
+  - On Hold
+  - Fix in Test Branch
+  - Broken Dependency
+  - bug
+  - Good First Issue
+  - help wanted
+  - "status: In Progress"
+  - Waiting For Merge
+staleLabel: Inactive
+markComment: >
+   This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+closeComment: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![WireGuard + OpenVPN logo](logos.jpg)
 
-**[Is pivpn.io down?](https://p.datadoghq.com/sb/od1t7p4rmqi6x1fm-cd513e61b0eb77a5d5f6a52fe0662205?theme=dark)**
+**[Is pivpn.io down?](https://status.pivpn.io)**
 
 About
 -----

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -80,7 +80,7 @@ for CLIENT_NAME in "${CLIENTS_TO_REMOVE[@]}"; do
         if [ -n "$CONFIRM" ]; then
             REPLY="y"
         else
-            read -r -p "Do you really want to delete $CLIENT_NAME? [Y/n] "
+            read -r -p "Do you really want to delete $CLIENT_NAME? [y/N] "
         fi
 
         if [[ $REPLY =~ ^[Yy]$ ]]; then
@@ -129,6 +129,9 @@ for CLIENT_NAME in "${CLIENTS_TO_REMOVE[@]}"; do
                 fi
             fi
 
+        else
+            echo "Aborting operation"
+            exit 1
         fi
     fi
 


### PR DESCRIPTION
Fixes for #1212:
- Changes phrasing of the confirmation prompt when removing a wg config (from "[Y/n]" to "[y/N]")
- Prints to stdout that operation is aborted
- Returns exit code 1