### PR TITLE
Fix exit codes when running a secondary script

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -143,7 +143,7 @@ main(){
 		:
 	elif [ "$UpdateCmd" = "Update" ]; then
 		$SUDO ${pivpnScriptDir}/update.sh "$@"
-		exit 0
+		exit "$?"
 	elif [ "$UpdateCmd" = "Repair" ]; then
 		# shellcheck disable=SC1090
 		source "$setupVars"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -93,7 +93,7 @@ if [[ ! $EUID -eq 0 ]];then
         export SUDO="sudo"
     else
     echo "::: Please install sudo or run this as root."
-    exit 0
+    exit 1
   fi
 fi
 

--- a/scripts/openvpn/pivpn.sh
+++ b/scripts/openvpn/pivpn.sh
@@ -16,18 +16,18 @@ vpn="openvpn"
 function makeOVPNFunc {
     shift
     $SUDO ${scriptDir}/${vpn}/makeOVPN.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 function listClientsFunc {
     shift
     $SUDO ${scriptDir}/${vpn}/clientStat.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 function listOVPNFunc {
     $SUDO ${scriptDir}/${vpn}/listOVPN.sh
-    exit 0
+    exit "$?"
 }
 
 function debugFunc {
@@ -37,29 +37,29 @@ function debugFunc {
     echo "::: Debug output completed above."
     echo "::: Copy saved to /tmp/debug.log"
     echo "::: "
-    exit 0
+    exit "$?"
 }
 
 function removeOVPNFunc {
     shift
     $SUDO ${scriptDir}/${vpn}/removeOVPN.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 function uninstallFunc {
     $SUDO ${scriptDir}/uninstall.sh "${vpn}"
-    exit 0
+    exit "$?"
 }
 
 function update {
     shift
     $SUDO ${scriptDir}/update.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 function backup {
     $SUDO ${scriptDir}/backup.sh "${vpn}"
-    exit 0
+    exit "$?"
 }
 
 

--- a/scripts/pivpn
+++ b/scripts/pivpn
@@ -14,12 +14,12 @@ scriptDir="/opt/pivpn"
 
 uninstallServer(){
     $SUDO ${scriptDir}/uninstall.sh
-    exit 0
+    exit "$?"
 }
 
 backup(){
     $SUDO ${scriptDir}/backup.sh
-    exit 0
+    exit "$?"
 }
 
 showHelp(){

--- a/scripts/wireguard/pivpn.sh
+++ b/scripts/wireguard/pivpn.sh
@@ -16,13 +16,13 @@ vpn="wireguard"
 makeConf(){
     shift
     $SUDO ${scriptdir}/${vpn}/makeCONF.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 listConnected(){
     shift
     $SUDO ${scriptdir}/${vpn}/clientSTAT.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 debug(){
@@ -32,52 +32,52 @@ debug(){
     echo "::: Debug output completed above."
     echo "::: Copy saved to /tmp/debug.log"
     echo "::: "
-    exit 0
+    exit "$?"
 }
 
 listClients(){
     $SUDO ${scriptdir}/${vpn}/listCONF.sh
-    exit 0
+    exit "$?"
 }
 
 showQrcode(){
     shift
     $SUDO ${scriptdir}/${vpn}/qrcodeCONF.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 removeClient(){
     shift
     $SUDO ${scriptdir}/${vpn}/removeCONF.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 disableClient(){
     shift
     $SUDO ${scriptdir}/${vpn}/disableCONF.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 enableClient(){
     shift
     $SUDO ${scriptdir}/${vpn}/enableCONF.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 uninstallServer(){
     $SUDO ${scriptdir}/uninstall.sh "${vpn}"
-    exit 0
+    exit "$?"
 }
 
 updateScripts(){
     shift
     $SUDO ${scriptdir}/update.sh "$@"
-    exit 0
+    exit "$?"
 }
 
 backup(){
     $SUDO ${scriptdir}/backup.sh "${vpn}"
-    exit 0
+    exit "$?"
 }
 
 showHelp(){


### PR DESCRIPTION
When running a secondary script, the exit code of the main script will use the exit code from the secondary script instead of always returning 0.  That way errors can be detected by the exit code when using the main pivpn script.  

Also, fixed an exit code when running install.sh without sudo to return 1 instead of 0.  

This is related to Issue #1231