### PR TITLE
Fixed shellcheck warning SC2004, SC2006, SC2129, SC2219. Issue #1233.

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -764,9 +764,11 @@ getStaticIPv4Settings() {
 			echo "::: Skipping setting static IP address"
 		fi
 
-		echo "dhcpReserv=${dhcpReserv}" >> ${tempsetupVarsFile}
-		echo "IPv4addr=${IPv4addr}" >> ${tempsetupVarsFile}
-		echo "IPv4gw=${IPv4gw}" >> ${tempsetupVarsFile}
+		{
+		echo "dhcpReserv=${dhcpReserv}"
+		echo "IPv4addr=${IPv4addr}"
+		echo "IPv4gw=${IPv4gw}"
+		} >> ${tempsetupVarsFile}
 		return
 	fi
 
@@ -1099,10 +1101,12 @@ installPiVPN(){
 
 	fi
 
-	echo "pivpnDEV=${pivpnDEV}" >> ${tempsetupVarsFile}
-	echo "pivpnNET=${pivpnNET}" >> ${tempsetupVarsFile}
-	echo "subnetClass=${subnetClass}" >> ${tempsetupVarsFile}
-	echo "ALLOWED_IPS=\"${ALLOWED_IPS}\"" >> ${tempsetupVarsFile}
+	{
+	echo "pivpnDEV=${pivpnDEV}"
+	echo "pivpnNET=${pivpnNET}"
+	echo "subnetClass=${subnetClass}"
+	echo "ALLOWED_IPS=\"${ALLOWED_IPS}\""
+	} >> ${tempsetupVarsFile}
 }
 
 askWhichVPN(){
@@ -1737,9 +1741,11 @@ askEncryption(){
 			fi
 		fi
 
-		echo "TWO_POINT_FOUR=${TWO_POINT_FOUR}" >> ${tempsetupVarsFile}
-		echo "pivpnENCRYPT=${pivpnENCRYPT}" >> ${tempsetupVarsFile}
-		echo "USE_PREDEFINED_DH_PARAM=${USE_PREDEFINED_DH_PARAM}" >> ${tempsetupVarsFile}
+		{
+		echo "TWO_POINT_FOUR=${TWO_POINT_FOUR}"
+		echo "pivpnENCRYPT=${pivpnENCRYPT}"
+		echo "USE_PREDEFINED_DH_PARAM=${USE_PREDEFINED_DH_PARAM}"
+		} >> ${tempsetupVarsFile}
 		return
 	fi
 
@@ -1747,9 +1753,11 @@ askEncryption(){
 		if [ "$VPN" = "openvpn" ]; then
 			TWO_POINT_FOUR=1
 			pivpnENCRYPT=256
-			echo "TWO_POINT_FOUR=${TWO_POINT_FOUR}" >> ${tempsetupVarsFile}
-			echo "pivpnENCRYPT=${pivpnENCRYPT}" >> ${tempsetupVarsFile}
-			echo "USE_PREDEFINED_DH_PARAM=${USE_PREDEFINED_DH_PARAM}" >> ${tempsetupVarsFile}
+			{
+			echo "TWO_POINT_FOUR=${TWO_POINT_FOUR}"
+			echo "pivpnENCRYPT=${pivpnENCRYPT}"
+			echo "USE_PREDEFINED_DH_PARAM=${USE_PREDEFINED_DH_PARAM}"
+			} >> ${tempsetupVarsFile}
 			return
 		fi
 	fi
@@ -1782,9 +1790,11 @@ askEncryption(){
 		USE_PREDEFINED_DH_PARAM=0
 	fi
 
-	echo "TWO_POINT_FOUR=${TWO_POINT_FOUR}" >> ${tempsetupVarsFile}
-	echo "pivpnENCRYPT=${pivpnENCRYPT}" >> ${tempsetupVarsFile}
-	echo "USE_PREDEFINED_DH_PARAM=${USE_PREDEFINED_DH_PARAM}" >> ${tempsetupVarsFile}
+	{
+	echo "TWO_POINT_FOUR=${TWO_POINT_FOUR}"
+	echo "pivpnENCRYPT=${pivpnENCRYPT}"
+	echo "USE_PREDEFINED_DH_PARAM=${USE_PREDEFINED_DH_PARAM}"
+	} >> ${tempsetupVarsFile}
 }
 
 cidrToMask(){

--- a/scripts/openvpn/makeOVPN.sh
+++ b/scripts/openvpn/makeOVPN.sh
@@ -133,7 +133,7 @@ function useBitwarden() {
     # login and unlock vault
     printf "****Bitwarden Login****"
     printf "\n"
-    SESSION_KEY=`bw login --raw`
+    SESSION_KEY=$(bw login --raw)
     export BW_SESSION=$SESSION_KEY
     printf "Successfully Logged in!"
     printf "\n"
@@ -168,7 +168,7 @@ function useBitwarden() {
     printf "Creating a PiVPN item for your vault..."
     printf "\n"
     # create a new item for your PiVPN Password
-    PASSWD=`bw generate -usln --length $LENGTH`
+    PASSWD=$(bw generate -usln --length $LENGTH)
     bw get template item | jq '.login.type = "1"'| jq '.name = "PiVPN"' | jq -r --arg NAME "$NAME" '.login.username = $NAME' | jq -r --arg PASSWD "$PASSWD" '.login.password = $PASSWD' |  bw encode | bw create item
     bw logout
 

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -60,7 +60,7 @@ if [[ -z "${CERTS_TO_REVOKE}" ]]; then
                 # Prevent printing "server" certificate
                 CERTS[$i]=$(echo -e "${NAME}")
             fi
-            let i=i+1
+            ((i++))
         fi
     done <${INDEX}
     
@@ -82,7 +82,7 @@ if [[ -z "${CERTS_TO_REVOKE}" ]]; then
 
     re='^[0-9]+$'
     if [[ ${NAME} =~ $re ]] ; then
-        NAME=${CERTS[$(($NAME))]}
+        NAME=${CERTS[$((NAME))]}
     fi
 
     for((x=1;x<=i;++x)); do
@@ -104,7 +104,7 @@ else
         if [[ "${STATUS}" = "V" ]]; then
             NAME=$(echo -e "$line" | sed -e 's:.*/CN=::')
             CERTS[$i]=${NAME}
-            let i=i+1
+            ((i++))
         fi
     done <${INDEX}
 

--- a/scripts/wireguard/disableCONF.sh
+++ b/scripts/wireguard/disableCONF.sh
@@ -81,7 +81,7 @@ for CLIENT_NAME in "${CLIENTS_TO_CHANGE[@]}"; do
 
     re='^[0-9]+$'
     if [[ ${CLIENT_NAME} =~ $re ]] ; then
-        CLIENT_NAME=${LIST[$(($CLIENT_NAME -1))]}
+        CLIENT_NAME=${LIST[$((CLIENT_NAME -1))]}
     fi
 
     if ! grep -q "^${CLIENT_NAME} " configs/clients.txt; then

--- a/scripts/wireguard/enableCONF.sh
+++ b/scripts/wireguard/enableCONF.sh
@@ -79,7 +79,7 @@ for CLIENT_NAME in "${CLIENTS_TO_CHANGE[@]}"; do
 
     re='^[0-9]+$'
     if [[ ${CLIENT_NAME} =~ $re ]] ; then
-        CLIENT_NAME=${LIST[$(($CLIENT_NAME -1))]}
+        CLIENT_NAME=${LIST[$((CLIENT_NAME -1))]}
     fi
 
     if ! grep -q "^${CLIENT_NAME} " configs/clients.txt; then

--- a/scripts/wireguard/qrcodeCONF.sh
+++ b/scripts/wireguard/qrcodeCONF.sh
@@ -55,7 +55,7 @@ fi
 for CLIENT_NAME in "${CLIENTS_TO_SHOW[@]}"; do
     re='^[0-9]+$'
     if [[ ${CLIENT_NAME} =~ $re ]] ; then
-        CLIENT_NAME=${LIST[$(($CLIENT_NAME -1))]}
+        CLIENT_NAME=${LIST[$((CLIENT_NAME -1))]}
     fi    
     if grep -qw "${CLIENT_NAME}" clients.txt; then
         echo -e "::: Showing client \e[1m${CLIENT_NAME}\e[0m below"

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -70,7 +70,7 @@ for CLIENT_NAME in "${CLIENTS_TO_REMOVE[@]}"; do
 
     re='^[0-9]+$'
     if [[ ${CLIENT_NAME} =~ $re ]] ; then
-        CLIENT_NAME=${LIST[$(($CLIENT_NAME -1))]}
+        CLIENT_NAME=${LIST[$((CLIENT_NAME -1))]}
     fi
 
     if ! grep -q "^${CLIENT_NAME} " configs/clients.txt; then


### PR DESCRIPTION
SC2004: "$/${} is unnecessary on arithmetic variables."
SC2006: "Use $(...) notation instead of legacy backticked `...`."
SC2129: "Consider using { cmd1; cmd2; } >> file instead of individual redirects."
SC2219: "Instead of 'let expr', prefer (( expr ))."