### PR TITLE
Skip WireGuard module build on Raspbian if it's built-in

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1254,7 +1254,7 @@ installWireGuard(){
 		echo "::: Installing WireGuard from Debian package... "
 
 		if [ -z "$AVAILABLE_WIREGUARD" ]; then
-			echo "::: Adding Raspbian repository... "
+			echo "::: Adding Raspbian Bullseye repository... "
 			echo "deb http://raspbian.raspberrypi.org/raspbian/ bullseye main" | $SUDO tee /etc/apt/sources.list.d/pivpn-bullseye-repo.list > /dev/null
 
 			# Do not upgrade packages from the bullseye repository except for wireguard
@@ -1266,7 +1266,13 @@ installWireGuard(){
 		fi
 
 		# qrencode is used to generate qrcodes from config file, for use with mobile clients
-		PIVPN_DEPS=(raspberrypi-kernel-headers wireguard-tools wireguard-dkms qrencode)
+		PIVPN_DEPS=(wireguard-tools qrencode)
+
+		if [ "$WIREGUARD_BUILTIN" -eq 0 ]; then
+			# Explicitly install the module if not built-in
+			PIVPN_DEPS+=(raspberrypi-kernel-headers wireguard-dkms)
+		fi
+
 		installDependentPackages PIVPN_DEPS[@]
 
 	elif [ "$PLAT" = "Debian" ]; then
@@ -1274,7 +1280,7 @@ installWireGuard(){
 		echo "::: Installing WireGuard from Debian package... "
 
 		if [ -z "$AVAILABLE_WIREGUARD" ]; then
-			echo "::: Adding Debian repository... "
+			echo "::: Adding Debian Bullseye repository... "
 			echo "deb https://deb.debian.org/debian/ bullseye main" | $SUDO tee /etc/apt/sources.list.d/pivpn-bullseye-repo.list > /dev/null
 
 			printf 'Package: *\nPin: release n=bullseye\nPin-Priority: -1\n\nPackage: wireguard wireguard-dkms wireguard-tools\nPin: release n=bullseye\nPin-Priority: 100\n' | $SUDO tee /etc/apt/preferences.d/pivpn-limit-bullseye > /dev/null


### PR DESCRIPTION
Meanwhile the Raspberry Pi kernel package with Linux 5.10 and built-in WireGuard module has been released. It hence became effective to make use of the built-in module check on Raspbian as well to skip the overhead of kernel headers install and DKMS module build.

Additionally, when adding Bullseye repositories to make available the WireGuard packages, say so explicitly. "Adding Debian repository" / "Adding Raspbian repository" is confusing when running a Debian / Raspbian system with those repositories added already, only with an older distro release.