### PR TITLE
Fixed shellcheck issue SC2015

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1810,7 +1810,7 @@ askEncryption(){
 cidrToMask(){
 	# Source: https://stackoverflow.com/a/20767392
 	set -- $(( 5 - ($1 / 8) )) 255 255 255 255 $(( (255 << (8 - ($1 % 8))) & 255 )) 0 0 0
-	[ $1 -gt 1 ] && shift $1 || shift
+	shift $1
 	echo ${1-0}.${2-0}.${3-0}.${4-0}
 }
 

--- a/scripts/openvpn/makeOVPN.sh
+++ b/scripts/openvpn/makeOVPN.sh
@@ -422,7 +422,7 @@ fi
 cidrToMask(){
 	# Source: https://stackoverflow.com/a/20767392
 	set -- $(( 5 - ($1 / 8) )) 255 255 255 255 $(( (255 << (8 - ($1 % 8))) & 255 )) 0 0 0
-	[ $1 -gt 1 ] && shift $1 || shift
+	shift $1
 	echo ${1-0}.${2-0}.${3-0}.${4-0}
 }
 


### PR DESCRIPTION
SC2015: Note that A && B || C is not if-then-else. C may run when A is true.

Replaced `[ $1 -gt 1 ] && shift $1 || shift` with `shift $1` since
`shift 1` is identical to `shift`.