### PR TITLE
Fixed shellcheck issue SC2148

### DIFF
--- a/scripts/openvpn/bash-completion
+++ b/scripts/openvpn/bash-completion
@@ -1,3 +1,4 @@
+#!/bin/bash
 _pivpn()
 {
     local cur prev opts

--- a/scripts/wireguard/bash-completion
+++ b/scripts/wireguard/bash-completion
@@ -1,3 +1,4 @@
+#!/bin/bash
 _pivpn()
 {
     local cur prev opts


### PR DESCRIPTION
SC2148: Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.

https://github.com/pivpn/pivpn/issues/1233