### PR TITLE
Fixed shellcheck warning SC2034

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -29,7 +29,6 @@ debianOvpnUserGroup="openvpn:openvpn"
 
 ######## PKG Vars ########
 PKG_MANAGER="apt-get"
-PKG_CACHE="/var/lib/apt/lists/"
 ### FIXME: quoting UPDATE_PKG_CACHE and PKG_INSTALL hangs the script, shellcheck SC2086
 UPDATE_PKG_CACHE="${PKG_MANAGER} update -y"
 PKG_INSTALL="${PKG_MANAGER} --yes --no-install-recommends install"

--- a/scripts/wireguard/bash-completion
+++ b/scripts/wireguard/bash-completion
@@ -1,9 +1,8 @@
 _pivpn()
 {
-    local cur prev opts
+    local cur opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
     dashopts="-a -c -d -l -qr -r -h -u -up -bk -off -on"
     opts="add clients debug list qrcode remove help uninstall update backup (temp) off (temp) on"
     if [ "${#COMP_WORDS[@]}" -eq 2 ]

--- a/scripts/wireguard/clientSTAT.sh
+++ b/scripts/wireguard/clientSTAT.sh
@@ -2,7 +2,6 @@
 # PiVPN: client status script
 
 CLIENTS_FILE="/etc/wireguard/configs/clients.txt"
-CONF_FILE="/etc/wireguard/wg0.conf"
 
 if [ ! -s "$CLIENTS_FILE" ]; then
     echo "::: There are no clients to list"


### PR DESCRIPTION
SC2034: ___ appears unused. Verify use (or export if used externally).

I opted to remove the variables since they didn't seem to be used
anywhere.

Also wanted to test making two simultaneous pull requests to check if Github imploded.

https://github.com/pivpn/pivpn/issues/1233