### PR TITLE
Fixed shellcheck warnings SC2178 and SC2128.

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -689,7 +689,8 @@ validIP(){
 }
 
 validIPAndNetmask(){
-	local ip=$1
+	local ip
+	ip=$1
 	local stat=1
 	ip="${ip/\//.}"
 


### PR DESCRIPTION
SC2178: Variable was used as an array but is now assigned a string.
SC2128: Expanding an array without an index only gives the first element.

It's apparently a known bug that shellcheck can't both declare a
variable local and assign a value to it without raising this issue.
https://github.com/koalaman/shellcheck/wiki/SC2178

https://github.com/pivpn/pivpn/issues/1233