### PR TITLE
ufw: add comment

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -2098,7 +2098,7 @@ confNetwork(){
 			$SUDO sed "/delete these required/i *nat\n:POSTROUTING ACCEPT [0:0]\n-I POSTROUTING -s ${pivpnNET}\/${subnetClass} -o ${IPv4dev} -j MASQUERADE -m comment --comment ${VPN}-nat-rule\nCOMMIT\n" -i /etc/ufw/before.rules
 		fi
 		# Insert rules at the beginning of the chain (in case there are other rules that may drop the traffic)
-		$SUDO ufw insert 1 allow "${pivpnPORT}"/"${pivpnPROTO}" comment vpn >/dev/null
+		$SUDO ufw insert 1 allow "${pivpnPORT}"/"${pivpnPROTO}" comment allow-${VPN} >/dev/null
 		$SUDO ufw route insert 1 allow in on "${pivpnDEV}" from "${pivpnNET}/${subnetClass}" out on "${IPv4dev}" to any >/dev/null
 
 		$SUDO ufw reload >/dev/null

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -2098,7 +2098,7 @@ confNetwork(){
 			$SUDO sed "/delete these required/i *nat\n:POSTROUTING ACCEPT [0:0]\n-I POSTROUTING -s ${pivpnNET}\/${subnetClass} -o ${IPv4dev} -j MASQUERADE -m comment --comment ${VPN}-nat-rule\nCOMMIT\n" -i /etc/ufw/before.rules
 		fi
 		# Insert rules at the beginning of the chain (in case there are other rules that may drop the traffic)
-		$SUDO ufw insert 1 allow "${pivpnPORT}"/"${pivpnPROTO}" >/dev/null
+		$SUDO ufw insert 1 allow "${pivpnPORT}"/"${pivpnPROTO}" comment vpn >/dev/null
 		$SUDO ufw route insert 1 allow in on "${pivpnDEV}" from "${pivpnNET}/${subnetClass}" out on "${IPv4dev}" to any >/dev/null
 
 		$SUDO ufw reload >/dev/null


### PR DESCRIPTION
if you have a lot of ufw rules and look at them via `sudo ufw status` it would be beneficial to have comments indicating the purpose of a rule (especially with ports which are not that well-known)

e.g. on a _raspberry pi_ with _pihole_
```
% ufw status
Status: active

To                         Action      From
--                         ------      ----
51820/udp                  ALLOW       Anywhere                   # vpn
22/tcp                     ALLOW       Anywhere                   # ssh
DNS                        ALLOW       Anywhere                   # dns
80/tcp                     ALLOW       Anywhere                   # http
22/tcp (v6)                ALLOW       Anywhere (v6)              # ssh
DNS (v6)                   ALLOW       Anywhere (v6)              # dns
80/tcp (v6)                ALLOW       Anywhere (v6)              # http
51820/udp (v6)             ALLOW       Anywhere (v6)              # vpn
```