### PR TITLE
Support setupVars for pivpnNET, subnetClass and ALLOWED_IPS via unattended setup

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1093,9 +1093,12 @@ installPiVPN(){
 			pivpnNET="10.6.0.0"
 		fi
 		vpnGw="${pivpnNET/.0.0/.0.1}"
-		# Forward all traffic through PiVPN (i.e. full-tunnel), may be modified by
-		# the user after the installation.
-		ALLOWED_IPS="0.0.0.0/0, ::0/0"
+		# Allow custom allowed IPs via unattend setupVARs file. Use default if not provided.
+		if [ -z "$ALLOWED_IPS" ]; then
+			# Forward all traffic through PiVPN (i.e. full-tunnel), may be modified by
+			# the user after the installation.
+			ALLOWED_IPS="0.0.0.0/0, ::0/0"
+		fi
 		CUSTOMIZE=0
 
 		installWireGuard

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1063,7 +1063,10 @@ installPiVPN(){
 	if [ "$VPN" = "openvpn" ]; then
 
 		pivpnDEV="tun0"
-		pivpnNET="10.8.0.0"
+		# Allow custom NET via unattend setupVARs file. Use default if not provided.
+		if [ -z "$pivpnNET" ]; then
+			pivpnNET="10.8.0.0"
+		fi
 		vpnGw="${pivpnNET/.0.0/.0.1}"
 
 		askAboutCustomizing
@@ -1085,7 +1088,10 @@ installPiVPN(){
 		# set the protocol here.
 		pivpnPROTO="udp"
 		pivpnDEV="wg0"
-		pivpnNET="10.6.0.0"
+		# Allow custom NET via unattend setupVARs file. Use default if not provided.
+		if [ -z "$pivpnNET" ]; then
+			pivpnNET="10.6.0.0"
+		fi
 		vpnGw="${pivpnNET/.0.0/.0.1}"
 		# Forward all traffic through PiVPN (i.e. full-tunnel), may be modified by
 		# the user after the installation.

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -24,7 +24,6 @@ piholeSetupVars="/etc/pihole/setupVars.conf"
 dnsmasqConfig="/etc/dnsmasq.d/02-pivpn.conf"
 
 dhcpcdFile="/etc/dhcpcd.conf"
-subnetClass="24"
 debianOvpnUserGroup="openvpn:openvpn"
 
 ######## PKG Vars ########
@@ -1055,6 +1054,11 @@ cloneOrUpdateRepos(){
 installPiVPN(){
 	$SUDO mkdir -p /etc/pivpn/
 	askWhichVPN
+
+	# Allow custom subnetClass via unattend setupVARs file. Use default if not provided.
+	if [ -z "$subnetClass" ]; then
+		subnetClass="24"
+	fi
 
 	if [ "$VPN" = "openvpn" ]; then
 

--- a/examples/unattended_openvpn_example.conf
+++ b/examples/unattended_openvpn_example.conf
@@ -4,6 +4,7 @@ IPv4gw=192.168.23.1
 dhcpReserv=0
 install_user=pi
 VPN=openvpn
+pivpnNET=10.8.0.0
 subnetClass=24
 pivpnPROTO=udp
 pivpnPORT=1194

--- a/examples/unattended_openvpn_example.conf
+++ b/examples/unattended_openvpn_example.conf
@@ -4,6 +4,7 @@ IPv4gw=192.168.23.1
 dhcpReserv=0
 install_user=pi
 VPN=openvpn
+subnetClass=24
 pivpnPROTO=udp
 pivpnPORT=1194
 pivpnDNS1=9.9.9.9

--- a/examples/unattended_wireguard_example.conf
+++ b/examples/unattended_wireguard_example.conf
@@ -3,6 +3,7 @@ install_user=pi
 VPN=wireguard
 pivpnNET=10.6.0.0
 subnetClass=24
+ALLOWED_IPS="0.0.0.0/0, ::0/0"
 pivpnPORT=51820
 pivpnDNS1=9.9.9.9
 pivpnDNS2=149.112.112.112

--- a/examples/unattended_wireguard_example.conf
+++ b/examples/unattended_wireguard_example.conf
@@ -1,7 +1,4 @@
 IPv4dev=eth0
-IPv4addr=192.168.23.211/24
-IPv4gw=192.168.23.1
-dhcpReserv=0
 install_user=pi
 VPN=wireguard
 pivpnPORT=51820

--- a/examples/unattended_wireguard_example.conf
+++ b/examples/unattended_wireguard_example.conf
@@ -1,6 +1,7 @@
 IPv4dev=eth0
 install_user=pi
 VPN=wireguard
+pivpnNET=10.6.0.0
 subnetClass=24
 pivpnPORT=51820
 pivpnDNS1=9.9.9.9

--- a/examples/unattended_wireguard_example.conf
+++ b/examples/unattended_wireguard_example.conf
@@ -1,6 +1,7 @@
 IPv4dev=eth0
 install_user=pi
 VPN=wireguard
+subnetClass=24
 pivpnPORT=51820
 pivpnDNS1=9.9.9.9
 pivpnDNS2=149.112.112.112


### PR DESCRIPTION
Support setupVars for `pivpnNET`, `subnetClass` and `ALLOWED_IPS` via unattended setup.

- **OpenVPN** --> `pivpnNET` and `subnetClass`
- **Wireguard** --> `pivpnNET`, `subnetClass` and `ALLOWED_IPS`

Fix part of https://github.com/pivpn/pivpn/issues/1273
