### PR TITLE
Fix errors on logging configuration

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -2151,10 +2151,13 @@ confNetwork(){
 }
 
 confLogging() {
+	# Pre-create rsyslog/logrotate config directories if missing, to assure logs are handled as expected when those are installed at a later time
+	$SUDO mkdir -p etc/{rsyslog,logrotate}.d 
+
 	echo "if \$programname == 'ovpn-server' then /var/log/openvpn.log
 if \$programname == 'ovpn-server' then stop" | $SUDO tee /etc/rsyslog.d/30-openvpn.conf > /dev/null
 
-  echo "/var/log/openvpn.log
+	echo "/var/log/openvpn.log
 {
 	rotate 4
 	weekly
@@ -2171,7 +2174,7 @@ if \$programname == 'ovpn-server' then stop" | $SUDO tee /etc/rsyslog.d/30-openv
 	# Restart the logging service
 	case ${PLAT} in
 		Debian|Raspbian|Ubuntu)
-			$SUDO systemctl restart rsyslog.service || true
+			$SUDO systemctl -q is-active rsyslog.service && $SUDO systemctl restart rsyslog.service
 		;;
 	esac
 }


### PR DESCRIPTION
rsyslog and/or logrotate may not be installed on the system, in which case creating the configurations may fail. As rsyslog and logrotate may be installed later on, it makes sense to pre-create those directories so that then OpenVPN logs are handled as expected.

Also, if the rsyslog service is not installed or not active, it should not and does not need to be restarted. Since there is not `-e` flag, ` || true` has not effect, but also, when using that flag it makes sense to exit if for some reason the running service couldn't be restarted, which may then be caused by the added configuration.