### PR TITLE
Remove debconf-apt-progress usage

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -543,13 +543,8 @@ installDependentPackages(){
 		# shellcheck disable=SC2086
 		$SUDO ${PKG_INSTALL} "${TO_INSTALL[@]}"
 	else
-		if command -v debconf-apt-progress > /dev/null; then
-			# shellcheck disable=SC2086
-			$SUDO debconf-apt-progress --logfile "${APTLOGFILE}" -- ${PKG_INSTALL} "${TO_INSTALL[@]}"
-		else
-			# shellcheck disable=SC2086
-			$SUDO ${PKG_INSTALL} "${TO_INSTALL[@]}"
-		fi
+		# shellcheck disable=SC2086
+		$SUDO ${PKG_INSTALL} "${TO_INSTALL[@]}"
 	fi
 
 	local FAILED=0


### PR DESCRIPTION
`debconf-apt-progress` is a tool to show a whiptail based dialog with progress bar for apt package installs, but it has some downsides:
- It aborts whenever apt or debconf halt for an interactive input, hence this would need to be prevented carefully, e.g. via `DEBIAN_FRONTEND=noninteractive` and `--force-confdef/old/new/miss`, while it is questionable whether PiVPN should mute such configuration inputs for users.
- It even aborts when such interactive input is not actually required in some cases, but triggered by some other debconf load internals: #1360

Most importantly, aside of the visually probably appealing progress bar, debconf-apt-progress has not any upsides but reduces transparency of what is actually done, and the installer has a fallback already.

This commit removes the debconf-apt-progress usage in favour of the fallback: direct apt-get usage.

Fixes #1360