### PR TITLE
Correct typo in Debug script output styling

### DIFF
--- a/scripts/wireguard/pivpnDEBUG.sh
+++ b/scripts/wireguard/pivpnDEBUG.sh
@@ -47,7 +47,7 @@ else
 fi
 
 printf "=============================================\n"
-echo -e ":::: \t\e[4mRecursive list of files in\e[0m\t ::::\n::::\e\t[4m/etc/wireguard shown below\e[0m\t ::::"
+echo -e ":::: \t\e[4mRecursive list of files in\e[0m\t ::::\n::::\t\e[4m/etc/wireguard shown below\e[0m\t ::::"
 ls -LR /etc/wireguard
 printf "=============================================\n"
 echo -e "::::\t\t\e[4mSelf check\e[0m\t\t ::::"


### PR DESCRIPTION
Compare with `scripts/openvpn/pivpnDebug.sh`, where the escape
characters are correctly sequenced for "a tab, and then some
styled text".