### PR TITLE
WireGuard: removeCONF: Remove ipv6 DNS entries too

### DIFF
--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -126,7 +126,7 @@ for CLIENT_NAME in "${CLIENTS_TO_REMOVE[@]}"; do
             # shellcheck disable=SC2154
             if [ -f /etc/pivpn/hosts.wireguard ]; then
                 NET_REDUCED="${pivpnNET::-2}"
-                sed "\#${NET_REDUCED}.${COUNT} ${CLIENT_NAME}.pivpn#d" -i /etc/pivpn/hosts.wireguard
+                sed -e "\#${NET_REDUCED}.${COUNT} ${CLIENT_NAME}.pivpn#d" -e "\#${pivpnNETv6}${COUNT} ${CLIENT_NAME}.pivpn#d" -i /etc/pivpn/hosts.wireguard
                 if killall -SIGHUP pihole-FTL; then
                     echo "::: Updated hosts file for Pi-hole"
                 else


### PR DESCRIPTION
Currently removing a client only removes the IPV4 entries from the `hosts.wireguard` file.

For IPv6, there is no need to have a NET_REDUCE since client `$COUNT` is incremented after the `::` in `$pivpnNETv6`