### PR TITLE
Ubuntu jammy Support and multiple updates to jammy

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,28 @@
+{
+  "name": "pivpn",
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "./CHANGELOG.md"
+      }
+    ],
+    ["@semantic-release/github", {
+      "assets": [
+        {"path": "dist/asset.min.css", "label": "CSS distribution"},
+        {"path": "dist/asset.min.js", "label": "JS distribution"}
+      ]
+    }]
+  ],
+    "release": {
+    "branches": [ "master", "beta", "test" ]
+  },
+
+  "branches": [
+    {name: 'master'},
+    {name: 'beta', channel: 'beta', prerelease: true},
+    {name: 'test', channel: 'test', prerelease: true}
+  ]
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ stages:
   - lint
   - style
   - test
+  - release
 
 branches:
   only:
@@ -21,7 +22,7 @@ jobs:
   include:
     - stage: lint
       name: "Shellcheck lint"
-      dist: focal
+      dist: jammy
       addons:
         apt:
           packages:
@@ -35,7 +36,7 @@ jobs:
 
     - stage: style
       name: "Shell Style Guide"
-      dist: xenial
+      dist: jammy
       addons:
         snaps:
           - shfmt
@@ -47,151 +48,106 @@ jobs:
         - find scripts/ -type f -exec shfmt -d -i 2 -ci -sr -bn {} \;
 
     - stage: test
-      name: "OpenVPN Xenial & Commands"
-      dist: xenial
-      virt: vm
-      arch: amd64
-      before_script: 
-        - cat /etc/os-release
-        - uname -a
-        - ip a
-        - sudo chmod +x ciscripts/startup.sh
-        - ./ciscripts/startup.sh -o
-      script:
-        - sudo ./auto_install/install.sh --unattended ciscripts/ci_openvpn.conf
-      after_script:
-        - systemctl status openvpn
-        - pivpn add -n foo nopass -d 180
-        - pivpn add -p "$RANDOM$RANDOM" -n bar -d 180
-        - pivpn add -o -n foo
-        - pivpn -bk
-        - ls ~pi/pivpnbackup/ | grep backup
-        - pivpn -l
-        - pivpn -c
-        - pivpn -r foo -y
-      after_fail:
-        - sudo journalctl -xe
-
-    - stage: test
-      name: "Wireguard Xenial & Commands"
-      dist: xenial
-      virt: vm
-      arch: amd64
-      before_script: 
-        - cat /etc/os-release
-        - uname -a
-        - ip a
-        - sudo chmod +x ciscripts/startup.sh
-        - ./ciscripts/startup.sh -w
-      script: 
-        - sudo ./auto_install/install.sh --unattended ciscripts/ci_wireguard.conf
-      after_script:
-        - systemctl status wg-quick@wg0
-        - pivpn add -n foo
-        - pivpn -qr foo
-        - pivpn -bk
-        - ls ~pi/pivpnbackup/ | grep backup
-        - pivpn -l
-        - pivpn -c
-        - pivpn -r foo -y
-      after_fail:
-        - sudo journalctl -xe
-
-    - stage: test
-      name: "OpenVPN Bionic & Commands"
+      name: "OpenVPN Bionic (18.04)"
       dist: bionic
       virt: vm
       arch: amd64
       before_script: 
-        - cat /etc/os-release
-        - uname -a
-        - ip a
-        - sudo chmod +x ciscripts/startup.sh
+        - sudo chmod +x ciscripts/*.sh
+        - ./ciscripts/pre_checks.sh
         - ./ciscripts/startup.sh -o
       script:
         - sudo ./auto_install/install.sh --unattended ciscripts/ci_openvpn.conf
-        - systemctl status openvpn
-        - pivpn add -n foo nopass -d 180
-        - pivpn add -p "$RANDOM$RANDOM" -n bar -d 180
-        - pivpn add -o -n foo
-        - pivpn -bk
-        - ls ~pi/pivpnbackup/ | grep backup
-        - pivpn -l
-        - pivpn -c
-        - pivpn -r foo -y
+        - ./ciscripts/test.sh -o
       after_fail:
         - sudo journalctl -xe
 
     - stage: test
-      name: "Wireguard Bionic & Commands"
+      name: "Wireguard Bionic (18.04)"
       dist: bionic
       virt: vm
       arch: amd64
       before_script: 
-        - cat /etc/os-release
-        - uname -a
-        - ip a
-        - sudo apt update -y
-        - sudo chmod +x ciscripts/startup.sh
+        - sudo chmod +x ciscripts/*.sh
+        - ./ciscripts/pre_checks.sh
         - ./ciscripts/startup.sh -w
       script: 
         - sudo ./auto_install/install.sh --unattended ciscripts/ci_wireguard.conf
-        - systemctl status wg-quick@wg0
-        - pivpn add -n foo
-        - pivpn -qr foo
-        - pivpn -bk
-        - ls ~pi/pivpnbackup/ | grep backup
-        - pivpn -l
-        - pivpn -c
-        - pivpn -r foo -y
+        - ./ciscripts/test.sh -w
       after_fail:
         - sudo journalctl -xe
 
     - stage: test
-      name: "OpenVPN Focal & Commands"
+      name: "OpenVPN Focal (20.04)"
       dist: focal
       virt: vm
       arch: amd64
       before_script: 
-        - cat /etc/os-release
-        - uname -a
-        - ip a
-        - sudo chmod +x ciscripts/startup.sh
+        - sudo chmod +x ciscripts/*.sh
+        - ./ciscripts/pre_checks.sh
         - ./ciscripts/startup.sh -o
       script:
         - sudo ./auto_install/install.sh --unattended ciscripts/ci_openvpn.conf
-        - systemctl status openvpn
-        - pivpn add -n foo nopass -d 180
-        - pivpn add -p "$RANDOM$RANDOM" -n bar -d 180
-        - pivpn add -o -n foo
-        - pivpn -bk
-        - ls ~pi/pivpnbackup/ | grep backup
-        - pivpn -l
-        - pivpn -c
-        - pivpn -r foo -y
+        - ./ciscripts/test.sh -o
       after_fail:
         - sudo journalctl -xe
 
     - stage: test
-      name: "Wireguard Focal & Commands"
+      name: "Wireguard Focal (20.04)"
       dist: focal
       virt: vm
       arch: amd64
       before_script: 
-        - cat /etc/os-release
-        - uname -a
-        - ip a
-        - sudo chmod +x ciscripts/startup.sh
+        - sudo chmod +x ciscripts/*.sh
+        - ./ciscripts/pre_checks.sh
         - ./ciscripts/startup.sh -w
       script: 
         - sudo ./auto_install/install.sh --unattended ciscripts/ci_wireguard.conf
-        - systemctl status wg-quick@wg0
-        - pivpn add -n foo
-        - pivpn -qr foo
-        - pivpn -bk
-        - ls ~pi/pivpnbackup/ | grep backup
-        - pivpn -l
-        - pivpn -c
-        - pivpn -r foo -y
+        - ./ciscripts/test.sh -w
       after_fail:
         - sudo journalctl -xe
+
+    - stage: test
+      name: "OpenVPN Jammy (22.04)"
+      dist: jammy
+      virt: vm
+      arch: amd64
+      before_script: 
+        - sudo chmod +x ciscripts/*.sh
+        - ./ciscripts/pre_checks.sh
+        - ./ciscripts/startup.sh -o
+      script:
+        - sudo ./auto_install/install.sh --unattended ciscripts/ci_openvpn.conf
+        - ./ciscripts/test.sh -o
+      after_fail:
+        - sudo journalctl -xe
+
+    - stage: test
+      name: "Wireguard Jammy (22.04)"
+      dist: jammy
+      virt: vm
+      arch: amd64
+      before_script: 
+        - sudo chmod +x ciscripts/*.sh
+        - ./ciscripts/pre_checks.sh
+        - ./ciscripts/startup.sh -w
+      script: 
+        - sudo ./auto_install/install.sh --unattended ciscripts/ci_wireguard.conf
+        - ./ciscripts/test.sh -w
+      after_fail:
+        - sudo journalctl -xe
+
+    - stage: "release"
+      name: "release" 
+      if: type = push
+      dist: jammy
+      virt: vm
+      arch: amd64
+      language: node_js
+      node_js:
+        - "node"
+      install:
+        - npm install @semantic-release/github -D
+        - npm install @semantic-release/changelog -D
+      script:
+        - npx semantic-release

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -351,7 +351,8 @@ distroCheck() {
       ["11"]="bullseye"
       ["16.04"]="xenial"
       ["18.04"]="bionic"
-      ["20.04"]="focal")
+      ["20.04"]="focal"
+      ["22.04"]="jammy")
     OSCN="${VER_MAP["${VER}"]}"
 
     # Alpine support
@@ -363,7 +364,7 @@ distroCheck() {
   case "${PLAT}" in
     Debian | Raspbian | Ubuntu)
       case "${OSCN}" in
-        stretch | buster | bullseye | xenial | bionic | focal)
+        stretch | buster | bullseye | xenial | bionic | focal | jammy)
           :
           ;;
         *)

--- a/ciscripts/pre_checks.sh
+++ b/ciscripts/pre_checks.sh
@@ -1,0 +1,5 @@
+#/bin/bash -e
+
+cat /etc/os-release
+uname -a
+ip a

--- a/ciscripts/startup.sh
+++ b/ciscripts/startup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 interface=$(ip -o link \
   | awk '{print $2}' \

--- a/ciscripts/test.sh
+++ b/ciscripts/test.sh
@@ -1,14 +1,53 @@
-#!/bin/bash
+#!/bin/bash -e
 
-if command -v systemctl > /dev/null; then
-  systemctl status openvpn
-elif command -v rc-service > /dev/null; then
-  rc-service openvpn status
-fi
+# Tests multiple pivpn commands
 
-pivpn add -n foo
-pivpn -qr foo
-pivpn -bk
-pivpn -l
-pivpn -c
-pivpn -r foo -y
+testopenvpn() {
+  if command -v systemctl > /dev/null; then
+    systemctl status openvpn
+  elif command -v rc-service > /dev/null; then
+    rc-service openvpn status
+  fi
+
+  pivpn add -n foo nopass -d 180
+  pivpn add -p "$RANDOM$RANDOM" -n bar -d 180
+  pivpn add -o -n foo
+  pivpn -bk
+  sudo ls ~pi/pivpnbackup/ | grep backup
+  pivpn -l
+  pivpn -c
+  pivpn -r foo -y
+  exit 0
+}
+
+testwireguard() {
+  if command -v systemctl > /dev/null; then
+    systemctl status wg-quick@wg0
+  elif command -v rc-service > /dev/null; then
+    rc-service wg-quick status
+  fi
+
+  pivpn add -n foo
+  pivpn -qr foo
+  pivpn -bk
+  sudo ls ~pi/pivpnbackup/ | grep backup
+  pivpn -l
+  pivpn -c
+  pivpn -r foo -y
+  exit 0
+}
+
+while true; do
+  case "${1}" in
+    -o | --openvpn)
+      testopenvpn
+      ;;
+    -w | --wireguard)
+      testwireguard
+      ;;
+    *)
+      err "unknown VPN protocol"
+      exit 1
+      ;;
+  esac
+done


### PR DESCRIPTION
Changes on this PR: 

* OS Support
  * Add Support and CI tests for Ubuntu Jammy
  * Removed CI tests for Ubuntu Xenial, Did not remove support for it yet. 

* Changes on CI System with the goal to streamline the testing / release process. 
  * Added multiple scripts to be used bu ci testing, the goal is to keep the CI code more "DRY" and avoid too much code repetition. 
  * Added the `-e` flag to the scripts so they exit if any error occurs thus failing the whole pipeline. 
  * Added semantic-release, this will analyze the commits and will tag the code and create releases with Updated changes removing the need to edit the CHANGELOG.md before merging to master.


Considering That PiVPN is far from the v1.10 existing here: https://github.com/pivpn/pivpn/releases I am planning to Manually create a "dummy" release to v4.0.0  (Number is taken based on rough estimation on the amount of times we introduced breaking changes).  

Once the dummy version bump is created, after this PR is merged to test branch a v4.1.0-test.1 will be created, and once test branch is merged to master a v4.1.0 release will be created. 

@orazioedoardo you agree with this version number? should it be different? any suggestion? 




Tests for Alpine will come on a later PR.