### PR TITLE
fix(dev-infra): move source to before var ref

### DIFF
--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -6,11 +6,12 @@ pivpnPERSISTENTKEEPALIVE=""
 pivpnDNS2=""
 
 setupVars="/etc/pivpn/wireguard/setupVars.conf"
-# shellcheck disable=SC2154
-userGroup="${install_user}:${install_user}"
 
 # shellcheck disable=SC1090
 source "${setupVars}"
+
+# shellcheck disable=SC2154
+userGroup="${install_user}:${install_user}"
 
 ### Functions
 err() {


### PR DESCRIPTION
move file sourcing above first references to the variables it loads

userGroup var is being set using var $install_user that should be loaded from the setupVars.conf file.
the issue this brings is the chown of the configs dir (approx line 100 in makeCONF.sh) leaves that dir owned by root