### PR TITLE
Show correct information and fix error caused by dash on printf in clientStat.sh

### DIFF
--- a/scripts/openvpn/clientStat.sh
+++ b/scripts/openvpn/clientStat.sh
@@ -50,7 +50,7 @@ listClients() {
           fi
 
           printf "  \t  %s %s %s " "${array[7]}" "${array[8]}" "${array[10]}"
-          printf "- %s\n" "${array[9]}"
+          printf "%s\n" "${array[9]}"
           printf "\n"
         done < "${STATUS_LOG}"
       else


### PR DESCRIPTION
At line 53 of clientStat.sh there is a printf that starts with minus sign

`  53           printf "- %s\n" "${array[9]}"
  `

When **pivpn clients** command is executed the minus sign is interpreted as an option and the script fails by not printing the connection time.

I fixed the issue adding -- before the format string to disarm the minus sign.

`  53           printf -- "- %s\n" "${array[9]}"
`

Hope this helps.
Thanks
Bye.