### PR TITLE
Fix default handling to be as implied. Closes #1663

### DIFF
--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -321,7 +321,7 @@ askreboot() {
   printf "It is \\e[1mstrongly\\e[0m recommended to reboot "
   printf "after un-installation.\\n"
 
-  read -p "Would you like to reboot now? [y/n]: " -n 1 -r
+  read -p "Would you like to reboot now? [y/N]: " -n 1 -r
 
   echo
 

--- a/scripts/wireguard/disableCONF.sh
+++ b/scripts/wireguard/disableCONF.sh
@@ -106,7 +106,7 @@ for CLIENT_NAME in "${CLIENTS_TO_CHANGE[@]}"; do
       read -r -p "Confirm you want to disable ${CLIENT_NAME}? [Y/n] "
     fi
 
-    if [[ "${REPLY}" =~ ^[yY]$ ]] || [[ -z "${REPLY}" ]]; then
+    if [[ "${REPLY}" =~ ^[Yy]$ ]] || [[ -z "${REPLY}" ]]; then
       # Disable the peer section from the server config
       echo "${CLIENT_NAME}"
 

--- a/scripts/wireguard/disableCONF.sh
+++ b/scripts/wireguard/disableCONF.sh
@@ -106,7 +106,7 @@ for CLIENT_NAME in "${CLIENTS_TO_CHANGE[@]}"; do
       read -r -p "Confirm you want to disable ${CLIENT_NAME}? [Y/n] "
     fi
 
-    if [[ "${REPLY}" =~ ^[^nN]$ ]]; then
+    if [[ "${REPLY}" =~ ^[yY]$ ]] || [[ -z "${REPLY}" ]]; then
       # Disable the peer section from the server config
       echo "${CLIENT_NAME}"
 

--- a/scripts/wireguard/disableCONF.sh
+++ b/scripts/wireguard/disableCONF.sh
@@ -106,7 +106,7 @@ for CLIENT_NAME in "${CLIENTS_TO_CHANGE[@]}"; do
       read -r -p "Confirm you want to disable ${CLIENT_NAME}? [Y/n] "
     fi
 
-    if [[ "${REPLY}" =~ ^[Yy]$ ]]; then
+    if [[ "${REPLY}" =~ ^[^nN]$ ]]; then
       # Disable the peer section from the server config
       echo "${CLIENT_NAME}"
 

--- a/scripts/wireguard/enableCONF.sh
+++ b/scripts/wireguard/enableCONF.sh
@@ -106,7 +106,7 @@ for CLIENT_NAME in "${CLIENTS_TO_CHANGE[@]}"; do
       read -r -p "Confirm you want to enable ${CLIENT_NAME}? [Y/n] "
     fi
 
-    if [[ "${REPLY}" =~ ^[Yy]$ ]]; then
+    if [[ "${REPLY}" =~ ^[Yy]$ ]] || [[ -z "${REPLY}" ]]; then
       # Enable the peer section from the server config
       echo "${CLIENT_NAME}"
 


### PR DESCRIPTION
Make user input handling look for blanks so that implied defaults work properly.
This fixes #1663, which is correct in that when you have a user input question and you give the options Y/n or y/N, it is implied that the capitalized letter is what the program will default to if there is no input.