### PR TITLE
  fix(scripts): allow generating a QR code from a filename

### DIFF
--- a/scripts/wireguard/qrcodeCONF.sh
+++ b/scripts/wireguard/qrcodeCONF.sh
@@ -89,6 +89,13 @@ for CLIENT_NAME in "${CLIENTS_TO_SHOW[@]}"; do
     qrencode -t "${encoding}" < "${CLIENT_NAME}.conf"
 
     echo "====================================================================="
+  elif [[ -f "${CLIENT_NAME}" ]]; then
+    echo -e "::: Showing client \e[1m${CLIENT_NAME}\e[0m below"
+    echo "====================================================================="
+
+    qrencode -t "${encoding}" < "${CLIENT_NAME}"
+
+    echo "====================================================================="
   else
     echo -e "::: \e[1m${CLIENT_NAME}\e[0m does not exist"
   fi


### PR DESCRIPTION
(supersedes #1681, submitted to the wrong branch, sorry about that).

The last couple times I've used the qr generation functionality, I make the mistake of passing the filename instead of the client name. This time it annoyed me enough to do something about it :).

Thanks for this great tool!