### PR TITLE
Update install.sh to support wider Ubuntu detection

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -350,7 +350,9 @@ distroCheck() {
       ["11"]="bullseye"
       ["18.04"]="bionic"
       ["20.04"]="focal"
-      ["22.04"]="jammy")
+      ["22.04"]="jammy"
+      ["22.10"]="kinetic"
+      ["23.04"]="lunar")
     OSCN="${VER_MAP["${VER}"]}"
 
     # Alpine support
@@ -362,7 +364,7 @@ distroCheck() {
   case "${PLAT}" in
     Debian | Raspbian | Ubuntu)
       case "${OSCN}" in
-        stretch | buster | bullseye | xenial | bionic | focal | jammy)
+        stretch | buster | bullseye | xenial | bionic | focal | jammy | kinetic | lunar)
           :
           ;;
         *)

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -363,7 +363,7 @@ distroCheck() {
   case "${PLAT}" in
     Debian | Raspbian | Ubuntu)
       case "${OSCN}" in
-        stretch | buster | bullseye | xenial | bionic | focal | jammy | kinetic | lunar)
+        stretch | buster | bullseye | xenial | bionic | focal | jammy | lunar)
           :
           ;;
         *)

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -351,7 +351,6 @@ distroCheck() {
       ["18.04"]="bionic"
       ["20.04"]="focal"
       ["22.04"]="jammy"
-      ["22.10"]="kinetic"
       ["23.04"]="lunar")
     OSCN="${VER_MAP["${VER}"]}"
 


### PR DESCRIPTION
Add Ubuntu Lunar (Lobster) which is now available on cloud providers.
Tested with Lunar Lobster 23.04.