### PR TITLE
fix: Alpine container (LXC) wireguard support

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -43,7 +43,7 @@ BASE_DEPS+=(bsdmainutils bash-completion)
 
 BASE_DEPS_ALPINE=(git grep bind-tools newt net-tools bash-completion coreutils)
 BASE_DEPS_ALPINE+=(openssl util-linux openrc iptables ip6tables coreutils sed)
-BASE_DEPS_ALPINE+=(perl)
+BASE_DEPS_ALPINE+=(perl libqrencode-tools)
 
 # Dependencies that where actually installed by the script. For example if the
 # script requires grep and dnsutils but dnsutils is already installed, we save
@@ -664,17 +664,19 @@ preconfigurePackages() {
   #         if we want to load the kernel module
   # case 5: On Alpine Docker Container, the responsibility to have
   #         a WireGuard module on the host system is at user side
-  # case 6: On Debian (and Ubuntu), we can only reliably assume the
+  # case 6: On Alpine container, wireguard-tools is available
+  # case 7: On Debian (and Ubuntu), we can only reliably assume the
   #         headers package for amd64: linux-image-amd64
-  # case 7: On Ubuntu, additionally the WireGuard package needs to
+  # case 8: On Ubuntu, additionally the WireGuard package needs to
   #         be available, since we didn't test mixing Ubuntu repositories.
-  # case 8: Ubuntu focal has wireguard support
+  # case 9: Ubuntu focal has wireguard support
 
   if [[ "${WIREGUARD_BUILTIN}" -eq 1 && -n "${AVAILABLE_WIREGUARD}" ]] \
     || [[ "${WIREGUARD_BUILTIN}" -eq 1 && ("${PLAT}" == 'Debian' || "${PLAT}" == 'Raspbian') ]] \
     || [[ "${PLAT}" == 'Raspbian' ]] \
     || [[ "${PLAT}" == 'Alpine' && ! -f /.dockerenv && "$(uname -mrs)" =~ ^Linux\ +[0-9\.\-]+\-((lts)|(virt))\ +.*$ ]] \
     || [[ "${PLAT}" == 'Alpine' && -f /.dockerenv ]] \
+    || [[ "${PLAT}" == 'Alpine' && -n "${AVAILABLE_WIREGUARD}" ]] \
     || [[ "${PLAT}" == 'Debian' && "${DPKG_ARCH}" == 'amd64' ]] \
     || [[ "${PLAT}" == 'Ubuntu' && "${DPKG_ARCH}" == 'amd64' && -n "${AVAILABLE_WIREGUARD}" ]] \
     || [[ "${PLAT}" == 'Ubuntu' && "${DPKG_ARCH}" == 'arm64' && "${OSCN}" == 'focal' && -n "${AVAILABLE_WIREGUARD}" ]]; then


### PR DESCRIPTION
PiVPN can now be installed and used by LXC containers.

Problem:
During the installation process, I was not able to select Wireguard for installation. It ran the OpenVPN setup automatically without a previous selection.

Fixes:
1. the `AVAILABLE_WIREGUARD` was not detected for Alpine LXC containers therefore another case has been added
2. added `libqrencode-tools` to the dependencies for Alpine installations to generate and display qrcodes

Tested the changes myself with no problems.