### PR TITLE
fix(scripts): Match full client name when disabling

### DIFF
--- a/scripts/wireguard/disableCONF.sh
+++ b/scripts/wireguard/disableCONF.sh
@@ -97,7 +97,7 @@ for CLIENT_NAME in "${CLIENTS_TO_CHANGE[@]}"; do
 
   if ! grep -q "^${CLIENT_NAME} " configs/clients.txt; then
     echo -e "::: \e[1m${CLIENT_NAME}\e[0m does not exist"
-  elif grep -q "#\[disabled\] ### begin ${CLIENT_NAME}" wg0.conf; then
+  elif grep -q "#\[disabled\] ### begin ${CLIENT_NAME} ###" wg0.conf; then
     echo -e "::: \e[1m${CLIENT_NAME}\e[0m is already disabled"
   else
     if [[ -n "${CONFIRM}" ]]; then


### PR DESCRIPTION
This fix prevents "pivpn -off" from failing to disable a client when another client is already disabled and the disabled client name starts with the client name you're trying to disable. e.g. "user" wasn't able to be disabled if "user-1" was already disabled.