### PR TITLE
Fix: Change wording on the window

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1425,7 +1425,7 @@ chooseUser() {
     else
       if awk -F':' '$3>=1000 && $3<=60000 {print $1}' /etc/passwd \
         | grep -qw "${install_user}"; then
-        echo "::: ${install_user} will hold your ovpn and wireguard configurations."
+        echo "::: ${install_user} will hold your VPN client configuration files."
       else
         echo "::: User ${install_user} does not exist, creating..."
 

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1425,7 +1425,7 @@ chooseUser() {
     else
       if awk -F':' '$3>=1000 && $3<=60000 {print $1}' /etc/passwd \
         | grep -qw "${install_user}"; then
-        echo "::: ${install_user} will hold your ovpn configurations."
+        echo "::: ${install_user} will hold your ovpn and wireguard configurations."
       else
         echo "::: User ${install_user} does not exist, creating..."
 


### PR DESCRIPTION
For grammatical purposes, would this make sense to include wireguard in the window instead of [user] will hold your ovpn configurations. If not, feel free to close this PR as I always wondered why it wasn't added to the window to include wireguard. Thank you! 