### PR TITLE
Updates to subnet generation and client creation

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1746,19 +1746,22 @@ dotIPv4LastDec(){
 }
 
 decIPv4ToHex(){
-  local hex ip
-  hex="$(printf "%x\n" "$1")"
-  quartet_hi=${hex::$((${#hex} - 4))}
-  quartet_lo=${hex: -4:4}
-  ip+="${quartet_hi}:${quartet_lo}"
-  printf "%s\n" "${ip}"
+  local hex
+  hex="$(printf "%08x\n" "$1")"
+  quartet_hi=${hex:0:4}
+  quartet_lo=${hex:4:4}
+  # Removes leading zeros from quartets, purely for aesthetic reasons
+  # Source: https://stackoverflow.com/a/19861690
+  leading_zeros_hi="${quartet_hi%%[!0]*}"
+  leading_zeros_lo="${quartet_lo%%[!0]*}"
+  printf "%s:%s\n" "${quartet_hi#"${leading_zeros_hi}"}" "${quartet_lo#"${leading_zeros_lo}"}"
 }
 
 cidrToMask() {
   # Source: https://stackoverflow.com/a/20767392
-  set -- $((5 - ($1 / 8))) \
+  set -- $((5 - (${1} / 8))) \
     255 255 255 255 \
-    $(((255 << (8 - ($1 % 8))) & 255)) \
+    $(((255 << (8 - (${1} % 8))) & 255)) \
     0 0 0
   shift "${1}"
   echo "${1-0}.${2-0}.${3-0}.${4-0}"

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1814,6 +1814,7 @@ generateRandomSubnet(){
 
   local source_subnet="$1"
   local source_ip="${source_subnet%/*}"
+  # shellcheck disable=SC2155
   local source_ip_dec="$(dotIPv4ToDec "$source_ip")"
   local source_netmask="${source_subnet##*/}"
   local source_netmask_dec="$(( 2**32-1 ^ (2**(32-source_netmask)-1) ))"

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1714,7 +1714,7 @@ installPiVPN() {
   writeVPNTempVarsFile
 }
 
-decIPv4ToDot(){
+decIPv4ToDot() {
   local a b c d
   a=$(( ($1 & 4278190080) >> 24 ))
   b=$(( ($1 & 16711680) >> 16 ))
@@ -1728,24 +1728,24 @@ dotIPv4ToDec(){
   IFS='.'
   read -r -a array_ip <<< "$1"
   IFS=$original_ifs
-  printf "%s\n" $(( array_ip[0]*(16777216) + array_ip[1]*(65536) + array_ip[2]*(256) + array_ip[3] ))
+  printf "%s\n" $(( array_ip[0] * 16777216 + array_ip[1] * 65536 + array_ip[2] * 256 + array_ip[3] ))
 }
 
-dotIPv4FirstDec(){
+dotIPv4FirstDec() {
   local decimal_ip decimal_mask
   decimal_ip=$(dotIPv4ToDec "$1")
   decimal_mask=$(( 2**32-1 ^ (2**(32-$2)-1) ))
   printf "%s\n" "$(( decimal_ip & decimal_mask ))"
 }
 
-dotIPv4LastDec(){
+dotIPv4LastDec() {
   local decimal_ip decimal_mask_inv
   decimal_ip=$(dotIPv4ToDec "$1")
   decimal_mask_inv=$(( 2**(32-$2)-1 ))
   printf "%s\n" "$(( decimal_ip | decimal_mask_inv ))"
 }
 
-decIPv4ToHex(){
+decIPv4ToHex() {
   local hex
   hex="$(printf "%08x\n" "$1")"
   quartet_hi=${hex:0:4}
@@ -1782,23 +1782,23 @@ setVPNDefaultVars() {
 generateRandomSubnet(){
   # Source: https://community.openvpn.net/openvpn/wiki/AvoidRoutingConflicts
   declare -a excluded_subnets_dec=(
-    167772160 167772415 # 10.0.0.0/24
-    167772416 167772671 # 10.0.1.0/24
-    167837952 167838207 # 10.1.1.0/24
-    167840256 167840511 # 10.1.10.0/24
-    167903232 167903487 # 10.2.0.0/24
-    168296448 168296703 # 10.8.0.0/24
-    168427776 168428031 # 10.10.1.0/24
-    173693440 173693695 # 10.90.90.0/24
-    174326016 174326271 # 10.100.1.0/24
-    184549120 184549375 # 10.255.255.0/24
+    167772160 167772415   # 10.0.0.0/24
+    167772416 167772671   # 10.0.1.0/24
+    167837952 167838207   # 10.1.1.0/24
+    167840256 167840511   # 10.1.10.0/24
+    167903232 167903487   # 10.2.0.0/24
+    168296448 168296703   # 10.8.0.0/24
+    168427776 168428031   # 10.10.1.0/24
+    173693440 173693695   # 10.90.90.0/24
+    174326016 174326271   # 10.100.1.0/24
+    184549120 184549375   # 10.255.255.0/24
     3232235520 3232235775 # 192.168.0.0/24
     3232235776 3232236031 # 192.168.1.0/24
   )
 
   # Add numeric ranges to the previous array
-  readarray -t currently_used_subnets <<< "$(ip route show | \
-    grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}')"
+  readarray -t currently_used_subnets <<< "$(ip route show \
+    | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\/[0-9]{1,2}')"
 
   local used used_ip used_mask
   for used in "${currently_used_subnets[@]}"; do
@@ -1826,7 +1826,7 @@ generateRandomSubnet(){
 
   # Picking a random subnet would cause the same subnets to be checked multiple
   # times shall the number of subnets were small, so instead a random permutation
-  # is scanned to check a subnet only one.
+  # is scanned to check a subnet only once.
   local subnets_count="$(( 2**(target_netmask - source_netmask) ))"
   readarray -t random_perm <<< "$(shuf -i 0-"$(( subnets_count - 1 ))")"
   # random_perm=( 3221 9 8 431 7 [...] )
@@ -1860,8 +1860,8 @@ generateRandomSubnet(){
       # first_ip_excluded_subnet_dec | last_ip_excluded_subnet_dec    |
       #                              |                                |
       #                   first_ip_subnet_dec                last_ip_subnet_dec
-      if (( last_ip_excluded_subnet_dec >= first_ip_subnet_dec )) && \
-        (( first_ip_excluded_subnet_dec <= last_ip_subnet_dec )); then
+      if (( last_ip_excluded_subnet_dec >= first_ip_subnet_dec )) \
+        && (( first_ip_excluded_subnet_dec <= last_ip_subnet_dec )); then
         overlap=true
         break
       fi

--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -1828,7 +1828,7 @@ generateRandomSubnet() {
   # times shall the number of subnets were small, so instead a random permutation
   # is scanned to check a subnet only once.
   local subnets_count="$((2 ** (target_netmask - source_netmask)))"
-  readarray -t random_perm <<< "$(shuf -i 0-"$(( subnets_count - 1))")"
+  readarray -t random_perm <<< "$(shuf -i 0-"$((subnets_count - 1))")"
   # random_perm=( 3221 9 8 431 7 [...] )
 
   # Due to bash performance limitations, it's not pratical to check all subnets.
@@ -1836,7 +1836,7 @@ generateRandomSubnet() {
   # on a Pi Zero, we avoid doing more than about 5000 iteration.
   local max_tries="$subnets_count"
   if [ $((subnets_count * excluded_subnets_count)) -ge 5000 ]; then
-    max_tries="$(( 5000 / (excluded_subnets_count / 2) ))"
+    max_tries="$((5000 / (excluded_subnets_count / 2)))"
   fi
 
   local first_ip_subnet_dec last_ip_subnet_dec
@@ -1844,8 +1844,8 @@ generateRandomSubnet() {
   local overlap
   for ((i = 0; i < max_tries; i++)); do
 
-    first_ip_subnet_dec="$(( first_ip_target_subnet_dec + total_ips_target_subnet * random_perm[i] ))"
-    last_ip_subnet_dec="$(( first_ip_subnet_dec + total_ips_target_subnet - 1 ))"
+    first_ip_subnet_dec="$((first_ip_target_subnet_dec + total_ips_target_subnet * random_perm[i]))"
+    last_ip_subnet_dec="$((first_ip_subnet_dec + total_ips_target_subnet - 1))"
 
     overlap=false
 

--- a/scripts/ipaddr_utils.sh
+++ b/scripts/ipaddr_utils.sh
@@ -1,37 +1,37 @@
 #!/usr/bin/env bash
 
-decIPv4ToDot(){
+decIPv4ToDot() {
   local a b c d
-  a=$(( ($1 & 4278190080) >> 24 ))
-  b=$(( ($1 & 16711680) >> 16 ))
-  c=$(( ($1 & 65280) >> 8 ))
-  d=$(( $1 & 255 ))
+  a=$((($1 & 4278190080) >> 24))
+  b=$((($1 & 16711680) >> 16))
+  c=$((($1 & 65280) >> 8))
+  d=$(($1 & 255))
   printf "%s.%s.%s.%s\n" $a $b $c $d
 }
 
-dotIPv4ToDec(){
+dotIPv4ToDec() {
   local original_ifs=$IFS
   IFS='.'
   read -r -a array_ip <<< "$1"
   IFS=$original_ifs
-  printf "%s\n" $(( array_ip[0]*(16777216) + array_ip[1]*(65536) + array_ip[2]*(256) + array_ip[3] ))
+  printf "%s\n" $((array_ip[0] * 16777216 + array_ip[1] * 65536 + array_ip[2] * 256 + array_ip[3]))
 }
 
-dotIPv4FirstDec(){
+dotIPv4FirstDec() {
   local decimal_ip decimal_mask
   decimal_ip=$(dotIPv4ToDec "$1")
-  decimal_mask=$(( 2**32-1 ^ (2**(32-$2)-1) ))
-  printf "%s\n" "$(( decimal_ip & decimal_mask ))"
+  decimal_mask=$((2 ** 32 - 1 ^ (2 ** (32 - $2) - 1)))
+  printf "%s\n" "$((decimal_ip & decimal_mask))"
 }
 
-dotIPv4LastDec(){
+dotIPv4LastDec() {
   local decimal_ip decimal_mask_inv
   decimal_ip=$(dotIPv4ToDec "$1")
-  decimal_mask_inv=$(( 2**(32-$2)-1 ))
-  printf "%s\n" "$(( decimal_ip | decimal_mask_inv ))"
+  decimal_mask_inv=$((2 ** (32 - $2) - 1))
+  printf "%s\n" "$((decimal_ip | decimal_mask_inv))"
 }
 
-decIPv4ToHex(){
+decIPv4ToHex() {
   local hex
   hex="$(printf "%08x\n" "$1")"
   quartet_hi=${hex:0:4}

--- a/scripts/ipaddr_utils.sh
+++ b/scripts/ipaddr_utils.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+decIPv4ToDot(){
+  local a b c d
+  a=$(( ($1 & 4278190080) >> 24 ))
+  b=$(( ($1 & 16711680) >> 16 ))
+  c=$(( ($1 & 65280) >> 8 ))
+  d=$(( $1 & 255 ))
+  printf "%s.%s.%s.%s\n" $a $b $c $d
+}
+
+dotIPv4ToDec(){
+  local original_ifs=$IFS
+  IFS='.'
+  read -r -a array_ip <<< "$1"
+  IFS=$original_ifs
+  printf "%s\n" $(( array_ip[0]*(16777216) + array_ip[1]*(65536) + array_ip[2]*(256) + array_ip[3] ))
+}
+
+dotIPv4FirstDec(){
+  local decimal_ip decimal_mask
+  decimal_ip=$(dotIPv4ToDec "$1")
+  decimal_mask=$(( 2**32-1 ^ (2**(32-$2)-1) ))
+  printf "%s\n" "$(( decimal_ip & decimal_mask ))"
+}
+
+dotIPv4LastDec(){
+  local decimal_ip decimal_mask_inv
+  decimal_ip=$(dotIPv4ToDec "$1")
+  decimal_mask_inv=$(( 2**(32-$2)-1 ))
+  printf "%s\n" "$(( decimal_ip | decimal_mask_inv ))"
+}
+
+decIPv4ToHex(){
+  local hex ip
+  hex="$(printf "%x\n" "$1")"
+  quartet_hi=${hex::$((${#hex} - 4))}
+  quartet_lo=${hex: -4:4}
+  ip+="${quartet_hi}:${quartet_lo}"
+  printf "%s\n" "${ip}"
+}
+
+cidrToMask() {
+  # Source: https://stackoverflow.com/a/20767392
+  set -- $((5 - (${1} / 8))) \
+    255 255 255 255 \
+    $(((255 << (8 - (${1} % 8))) & 255)) \
+    0 0 0
+  shift "${1}"
+  echo "${1-0}.${2-0}.${3-0}.${4-0}"
+}

--- a/scripts/ipaddr_utils.sh
+++ b/scripts/ipaddr_utils.sh
@@ -32,12 +32,15 @@ dotIPv4LastDec(){
 }
 
 decIPv4ToHex(){
-  local hex ip
-  hex="$(printf "%x\n" "$1")"
-  quartet_hi=${hex::$((${#hex} - 4))}
-  quartet_lo=${hex: -4:4}
-  ip+="${quartet_hi}:${quartet_lo}"
-  printf "%s\n" "${ip}"
+  local hex
+  hex="$(printf "%08x\n" "$1")"
+  quartet_hi=${hex:0:4}
+  quartet_lo=${hex:4:4}
+  # Removes leading zeros from quartets, purely for aesthetic reasons
+  # Source: https://stackoverflow.com/a/19861690
+  leading_zeros_hi="${quartet_hi%%[!0]*}"
+  leading_zeros_lo="${quartet_lo%%[!0]*}"
+  printf "%s:%s\n" "${quartet_hi#"${leading_zeros_hi}"}" "${quartet_lo#"${leading_zeros_lo}"}"
 }
 
 cidrToMask() {

--- a/scripts/openvpn/makeOVPN.sh
+++ b/scripts/openvpn/makeOVPN.sh
@@ -291,11 +291,11 @@ fi
 
 # Exclude first, last and server addresses
 # shellcheck disable=SC2154
-MAX_CLIENTS="$((2**(32-subnetClass)-3))"
+MAX_CLIENTS="$((2 ** (32 - subnetClass) - 3))"
 
 # shellcheck disable=SC2154
-FIRST_IPV4_DEC="$(dotIPv4FirstDec "${pivpnNET}" "${subnetClass}" )"
-LAST_IPV4_DEC="$(dotIPv4LastDec "${pivpnNET}" "${subnetClass}" )"
+FIRST_IPV4_DEC="$(dotIPv4FirstDec "${pivpnNET}" "${subnetClass}")"
+LAST_IPV4_DEC="$(dotIPv4LastDec "${pivpnNET}" "${subnetClass}")"
 
 if [ "$(find /etc/openvpn/ccd -type f | wc -l)" -ge "${MAX_CLIENTS}" ]; then
   echo "::: Can't add any more clients (max. ${MAX_CLIENTS})!"
@@ -303,7 +303,7 @@ if [ "$(find /etc/openvpn/ccd -type f | wc -l)" -ge "${MAX_CLIENTS}" ]; then
 fi
 
 # Find an unused address for the client IP
-for (( ip = FIRST_IPV4_DEC+2; ip <= LAST_IPV4_DEC-1; ip++ )); do
+for ((ip = FIRST_IPV4_DEC + 2; ip <= LAST_IPV4_DEC - 1; ip++)); do
   # find returns 0 if the folder is empty, so we create the 'ls -A [...]'
   # exception to stop at the first static IP (10.8.0.2). Otherwise it would
   # cycle to the end without finding and available octet.

--- a/scripts/openvpn/makeOVPN.sh
+++ b/scripts/openvpn/makeOVPN.sh
@@ -17,6 +17,7 @@ source "${setupVars}"
 if [ ! -r /opt/pivpn/ipaddr_utils.sh ]; then
   exit 1
 fi
+# shellcheck disable=SC1091
 source /opt/pivpn/ipaddr_utils.sh
 
 # shellcheck disable=SC2154
@@ -289,8 +290,10 @@ if [[ ! -d "${install_home}/ovpns" ]]; then
 fi
 
 # Exclude first, last and server addresses
+# shellcheck disable=SC2154
 MAX_CLIENTS="$((2**(32-subnetClass)-3))"
 
+# shellcheck disable=SC2154
 FIRST_IPV4_DEC="$(dotIPv4FirstDec "${pivpnNET}" "${subnetClass}" )"
 LAST_IPV4_DEC="$(dotIPv4LastDec "${pivpnNET}" "${subnetClass}" )"
 

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -4,8 +4,14 @@
 ### Constants
 setupVars="/etc/pivpn/openvpn/setupVars.conf"
 INDEX="/etc/openvpn/easy-rsa/pki/index.txt"
+
 # shellcheck disable=SC1090
 source "${setupVars}"
+
+if [ ! -r /opt/pivpn/ipaddr_utils.sh ]; then
+  exit 1
+fi
+source /opt/pivpn/ipaddr_utils.sh
 
 ### Functions
 err() {
@@ -167,10 +173,8 @@ for ((ii = 0; ii < ${#CERTS_TO_REVOKE[@]}; ii++)); do
     # Disabling SC2154 $pivpnNET sourced externally
     # shellcheck disable=SC2154
     # Grab the client IP address
-    NET_REDUCED="${pivpnNET::-2}"
     STATIC_IP="$(grep -v "^#" /etc/openvpn/ccd/"${CERTS_TO_REVOKE[ii]}" \
-      | grep -w ifconfig-push \
-      | grep -oE "${NET_REDUCED}\.[0-9]{1,3}")"
+      | grep -w ifconfig-push | awk '{print $2}')"
     rm -rf /etc/openvpn/ccd/"${CERTS_TO_REVOKE[ii]}"
 
     # disablung warning SC2154, $install_home sourced externally

--- a/scripts/openvpn/removeOVPN.sh
+++ b/scripts/openvpn/removeOVPN.sh
@@ -11,6 +11,7 @@ source "${setupVars}"
 if [ ! -r /opt/pivpn/ipaddr_utils.sh ]; then
   exit 1
 fi
+# shellcheck disable=SC1091
 source /opt/pivpn/ipaddr_utils.sh
 
 ### Functions

--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -13,6 +13,7 @@ source "${setupVars}"
 if [ ! -r /opt/pivpn/ipaddr_utils.sh ]; then
   exit 1
 fi
+# shellcheck disable=SC1091
 source /opt/pivpn/ipaddr_utils.sh
 
 # shellcheck disable=SC2154
@@ -112,6 +113,7 @@ fi
 cd /etc/wireguard || exit
 
 # Exclude first, last and server addresses
+# shellcheck disable=SC2154
 MAX_CLIENTS="$((2**(32-subnetClass)-3))"
 
 if [ "$(wc -l configs/clients.txt | awk '{print $1}')" -ge "${MAX_CLIENTS}" ]; then
@@ -119,6 +121,7 @@ if [ "$(wc -l configs/clients.txt | awk '{print $1}')" -ge "${MAX_CLIENTS}" ]; t
   exit 1
 fi
 
+# shellcheck disable=SC2154
 FIRST_IPV4_DEC="$(dotIPv4FirstDec "${pivpnNET}" "${subnetClass}" )"
 LAST_IPV4_DEC="$(dotIPv4LastDec "${pivpnNET}" "${subnetClass}" )"
 

--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -114,7 +114,7 @@ cd /etc/wireguard || exit
 
 # Exclude first, last and server addresses
 # shellcheck disable=SC2154
-MAX_CLIENTS="$((2**(32-subnetClass)-3))"
+MAX_CLIENTS="$((2 ** (32 - subnetClass) - 3))"
 
 if [ "$(wc -l configs/clients.txt | awk '{print $1}')" -ge "${MAX_CLIENTS}" ]; then
   echo "::: Can't add any more clients (max. ${MAX_CLIENTS})!"
@@ -122,11 +122,11 @@ if [ "$(wc -l configs/clients.txt | awk '{print $1}')" -ge "${MAX_CLIENTS}" ]; t
 fi
 
 # shellcheck disable=SC2154
-FIRST_IPV4_DEC="$(dotIPv4FirstDec "${pivpnNET}" "${subnetClass}" )"
-LAST_IPV4_DEC="$(dotIPv4LastDec "${pivpnNET}" "${subnetClass}" )"
+FIRST_IPV4_DEC="$(dotIPv4FirstDec "${pivpnNET}" "${subnetClass}")"
+LAST_IPV4_DEC="$(dotIPv4LastDec "${pivpnNET}" "${subnetClass}")"
 
 # Find an unused address for the client IP
-for (( ip = FIRST_IPV4_DEC+2; ip <= LAST_IPV4_DEC-1; ip++ )); do
+for ((ip = FIRST_IPV4_DEC + 2; ip <= LAST_IPV4_DEC - 1; ip++)); do
   if ! grep -q " ${ip}$" configs/clients.txt; then
     UNUSED_IPV4_DEC="${ip}"
     break
@@ -202,7 +202,7 @@ echo "::: Client config generated"
 echo "::: Updated server config"
 
 echo "${CLIENT_NAME} $(< keys/"${CLIENT_NAME}"_pub) $(date +%s) ${UNUSED_IPV4_DEC}" \
-      | tee -a configs/clients.txt > /dev/null
+  | tee -a configs/clients.txt > /dev/null
 
 if [[ -f /etc/pivpn/hosts.wireguard ]]; then
   echo "${UNUSED_IPV4_DOT} ${CLIENT_NAME}.pivpn" \

--- a/scripts/wireguard/removeCONF.sh
+++ b/scripts/wireguard/removeCONF.sh
@@ -9,6 +9,7 @@ source "${setupVars}"
 if [ ! -r /opt/pivpn/ipaddr_utils.sh ]; then
   exit 1
 fi
+# shellcheck disable=SC1091
 source /opt/pivpn/ipaddr_utils.sh
 
 ### Functions


### PR DESCRIPTION
First off, now any subnet is allowed and when used, client IP addresses are correctly generated and do not assume /24, fixes https://github.com/pivpn/pivpn/issues/1267.

Then, the script will prevent adding more client than the subnet allows for, fixes https://github.com/pivpn/pivpn/issues/1683.

Last, edge cases in subnet generation when a user has 10.0.0.0/8 is addresses by checking another private network after 5000 iterations. Unfortunately I could not devise a way to efficiently check all empty available subnets so it's still probabilistic. In practice it work fine unless in extreme cases where there are very few holes and those are not checked.  Fixes: https://github.com/pivpn/pivpn/issues/1518.

IPv6 is taken care of by simply using the IPv4 as least significant quartets of the IPv6 address.