### PR TITLE
build: Add automated release actions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,20 @@
+name: Release
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.semrel.outputs.version }}
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: go-semantic-release/action@v1
+        id: semrel
+        name: Release
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Hi @orazioedoardo  since you're gonna keep maintaining this, you might find this handy. 

TravisCI ended up going out of credits all the time and I got tired of having to deal with them and ended up just removed the integration from the repository. 

This action is very similar to the package we had previously for doing this and much easier to use. [go-semantic-release](https://github.com/go-semantic-release/semantic-release). 

Automated tests are not working and they may need to be rebuild with github actions if you need them. 

Ps: Rebase and merge, don't use merge commits as they don't really work well with semantic versioning / semantic-releases.