### PR TITLE
feat(scripts): add the option to enter any Client IP from a given range

### DIFF
--- a/scripts/wireguard/makeCONF.sh
+++ b/scripts/wireguard/makeCONF.sh
@@ -27,11 +27,12 @@ err() {
 helpFunc() {
   echo "::: Create a client conf profile"
   echo ":::"
-  echo "::: Usage: pivpn <-a|add> [-n|--name <arg>] [-h|--help]"
+  echo "::: Usage: pivpn <-a|add> [-n|--name <arg>] [-ip|--client-ip <ipv4>] [-h|--help]"
   echo ":::"
   echo "::: Commands:"
   echo ":::  [none]               Interactive mode"
   echo ":::  -n,--name            Name for the Client (default: '${HOSTNAME}')"
+  echo ":::  -ip,--client-ip      IPv4 address of the Client"
   echo ":::  -h,--help            Show this help dialog"
 }
 
@@ -67,6 +68,18 @@ checkName() {
   fi
 }
 
+checkClientIP() {
+  local ip ipv4_regex
+  ip="$1"
+  ipv4_regex="^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}"
+  ipv4_regex+="(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$"
+
+  if [[ ! "${ip}" =~ $ipv4_regex ]]; then
+    err "::: Invalid IP: ${ip}"
+    exit 1
+  fi
+}
+
 ### Script
 if [[ ! -f "${setupVars}" ]]; then
   err "::: Missing setup vars file!"
@@ -92,6 +105,20 @@ while [[ "$#" -gt 0 ]]; do
 
       CLIENT_NAME="${_val}"
       checkName
+      ;;
+    -ip | --client-ip | --client-ip=*)
+      _val="${_key##--client-ip=}"
+
+      if [[ "${_val}" == "${_key}" ]]; then
+        [[ "$#" -lt 2 ]] \
+          && err "::: Missing value for the optional argument '${_key}'." \
+          && exit 1
+
+        _val="${2}"
+        shift
+      fi
+
+      CLIENT_IP="${_val}"
       ;;
     -h | --help)
       helpFunc
@@ -128,16 +155,43 @@ if [ "$(wc -l configs/clients.txt | awk '{print $1}')" -ge "${MAX_CLIENTS}" ]; t
 fi
 
 # shellcheck disable=SC2154
-FIRST_IPV4_DEC="$(dotIPv4FirstDec "${pivpnNET}" "${subnetClass}")"
-LAST_IPV4_DEC="$(dotIPv4LastDec "${pivpnNET}" "${subnetClass}")"
+NETID_IPV4_DEC="$(dotIPv4FirstDec "${pivpnNET}" "${subnetClass}")"
+BROADCAST_IPV4_DEC="$(dotIPv4LastDec "${pivpnNET}" "${subnetClass}")"
 
-# Find an unused address for the client IP
-for ((ip = FIRST_IPV4_DEC + 2; ip <= LAST_IPV4_DEC - 1; ip++)); do
+FIRST_IPV4_DEC=$((NETID_IPV4_DEC + 2))
+LAST_IPV4_DEC=$((BROADCAST_IPV4_DEC - 1))
+FIRST_IPV4="$(decIPv4ToDot "${FIRST_IPV4_DEC}")"
+LAST_IPV4="$(decIPv4ToDot "${LAST_IPV4_DEC}")"
+
+if [[ -z "${CLIENT_IP}" ]]; then
+  read -p "Enter the Client IP from range ${FIRST_IPV4} - ${LAST_IPV4} (optional): " CLIENT_IP
+fi
+
+if [[ -n "${CLIENT_IP}" ]]; then
+  checkClientIP "${CLIENT_IP}"
+  ip="$(dotIPv4ToDec "${CLIENT_IP}")"
+
+  if [[ "${ip}" -lt "${FIRST_IPV4_DEC}" || "${ip}" -gt "${LAST_IPV4_DEC}" ]]; then
+    err "::: The specified IP ${CLIENT_IP} is not in range ${FIRST_IPV4} - ${LAST_IPV4}"
+    exit 1
+  fi
+
   if ! grep -q " ${ip}$" configs/clients.txt; then
     UNUSED_IPV4_DEC="${ip}"
-    break
+  else
+    err "::: IP address ${CLIENT_IP} is already in use"
+    exit 1
   fi
-done
+else
+  # Find an unused address for the client IP
+  for ((ip = FIRST_IPV4_DEC; ip <= LAST_IPV4_DEC; ip++)); do
+    if ! grep -q " ${ip}$" configs/clients.txt; then
+      UNUSED_IPV4_DEC="${ip}"
+      echo "::: Chosen Client IP: $(decIPv4ToDot "${ip}")"
+      break
+    fi
+  done
+fi
 
 if [[ -z "${CLIENT_NAME}" ]]; then
   read -r -p "Enter a Name for the Client: " CLIENT_NAME


### PR DESCRIPTION
Add the `--client-ip` option to enter any Client IP from a given range when creating a client profile for **WireGuard** VPN. This gives the user better control over which IP address will be assigned to the client.

This option is optional - if not used, the first available IP address will be chosen.
So the current functionality remains unchanged.

<details><summary>Example:</summary>
<p>

```
$ pivpn -a -h
::: Create a client conf profile
:::
::: Usage: pivpn <-a|add> [-n|--name <arg>] [-ip|--client-ip <ipv4>] [-h|--help]
:::
::: Commands:
:::  [none]               Interactive mode
:::  -n,--name            Name for the Client (default: 'rpi5')
:::  -ip,--client-ip      IPv4 address of the Client
:::  -h,--help            Show this help dialog
```
```
$ pivpn -a
Enter the Client IP from range 10.207.82.2 - 10.207.82.254 (optional): 10.207.82.111
Enter a Name for the Client: custom_ip           
```
```
$ pivpn -a --client-ip 10.207.82.111
[2025-01-25T15:57:37+0100]: ::: IP address 10.207.82.111 is already in use
```
```
$ pivpn -a --client-ip 10.207.82.122
Enter a Name for the Client: custom_ip2
```
```
$ pivpn -c
::: Connected Clients List :::
Name                Remote IP                 Virtual IP                                         Bytes Received      Bytes Sent      Last Seen
custom_ip           (none)                    10.207.82.111,fd11:5ee:bad:c0de::acf:526f/128      0B                  0B              (not yet)
custom_ip2          (none)                    10.207.82.122,fd11:5ee:bad:c0de::acf:527a/128      0B                  0B              (not yet)
```


</p>
</details> 