### PR TITLE
Fix UFW throwing invalid position error during IPv6 configuration.

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -3399,7 +3399,7 @@ confNetwork() {
         out on "${IPv4dev}" to any > /dev/null
 
       if [[ "${pivpnenableipv6}" -eq 1 ]]; then
-        ${SUDO} ufw route insert 1 \
+        ${SUDO} ufw route \
           allow in on "${pivpnDEV}" \
           from "${pivpnNETv6}/${subnetClassv6}" \
           out on "${IPv6dev}" to any > /dev/null


### PR DESCRIPTION
UFW reports "ERROR: Invalid position at ‘1’" when attempting to insert an IPv6 rule above an IPv4 rule, which breaks IPv6 functionality on setups running UFW. This is fixed by appending the rule below all others.