### PR TITLE
(fix): Fix IPv6 address in config file

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -3270,10 +3270,10 @@ confWireGuard() {
   {
     echo '[Interface]'
     echo "PrivateKey = $(${SUDO} cat /etc/wireguard/keys/server_priv)"
-    echo -n "Address = ${vpnGw}/${subnetClass}"
+    echo "Address = ${vpnGw}/${subnetClass}"
 
     if [[ "${pivpnenableipv6}" -eq 1 ]]; then
-      echo ",${vpnGwv6}/${subnetClassv6}"
+      echo "Address = ${vpnGwv6}/${subnetClassv6}"
     else
       echo
     fi


### PR DESCRIPTION
I found this "error" (in quotes because it doesn't really break anything) while configuring WGDashboard. [Issue Here](https://github.com/donaldzou/WGDashboard/issues/658)

Essentially, the `wg0.conf` file layout changed and the IPv4 and IPv6 addresses are in different lines in the `[Interface]` section, as opposed to being separated by a comma.

You can check this by having a Wireguard setup with IPv4 and IPv6 and then run `wg-quick save wg0`. You'll see that the `wg-quick` utility will format the file with one line per address.

This PR helps bring uniformity with the `wg-quick` utility.