### PR TITLE
fix(install): consider /lib and /usr/lib both as valid module paths

### DIFF
--- a/auto_install/install.sh
+++ b/auto_install/install.sh
@@ -661,14 +661,9 @@ preconfigurePackages() {
   # the wireguard module so it'll appear builtin from the container's point of view.
   WIREGUARD_BUILTIN=0
 
-  if [[ "${OSCN}" == "trixie" ]]; then
-    module_search_path='/usr/lib/modules/*/wireguard.ko*'
-  else
-    module_search_path='/lib/modules/*/wireguard.ko*'
-  fi
-
   if [[ "${PKG_MANAGER}" == 'apt-get' ]]; then
-    if dpkg-query -S "${module_search_path}" &> /dev/null \
+    if dpkg-query -S '/lib/modules/*/wireguard.ko*' &> /dev/null \
+      || dpkg-query -S '/usr/lib/modules/*/wireguard.ko*' &> /dev/null \
       || modinfo wireguard 2> /dev/null \
       | grep -q '^filename:[[:blank:]]*(builtin)$' \
       || lsmod | grep -q '^wireguard'; then


### PR DESCRIPTION
Since Debian Trixie, `/usr/lib/modules` is correctly considered as valid kernel module path, but 3rd party packages can formell still ship modules below `/lib/modules`, or below `/usr/lib/modules` as well on older Debian versions. Since `usrmerge`, both are effectively the same directory anyway.

Hence always consider both paths.

An alternative would be to use `modprobe wireguard &> /dev/null` only. It does not reveal whether the module is part of a package or was installed via DKMS. But even if DKMS was used, PiVPN wouldn't need to do anything different, since, obviously, DKMS is present already, and designed to automatically compile its modules on kernel upgrades.

Let me know whether I should open against `test` branch, though they are identical at time of writing.