### PR TITLE
Fix for recent grep versions and Alpine check

### DIFF
--- a/scripts/openvpn/pivpn.sh
+++ b/scripts/openvpn/pivpn.sh
@@ -3,7 +3,7 @@
 ### Constants
 CHECK_PKG_INSTALLED='dpkg-query -s'
 
-if grep -qsEe "^NAME\=['\"]?Alpine[a-zA-Z ]*['\"]?$" /etc/os-release; then
+if test -f /etc/alpine-release && which apk > /dev/null; then
   CHECK_PKG_INSTALLED='apk --no-cache info -e'
 fi
 

--- a/scripts/pivpn
+++ b/scripts/pivpn
@@ -42,7 +42,7 @@ if [[ "${EUID}" -ne 0 ]]; then
   fi
 fi
 
-if grep -qsEe "^NAME\=['\"]?Alpine[a-zA-Z ]*['\"]?$" /etc/os-release; then
+if test -f /etc/alpine-release && which apk > /dev/null; then
   CHECK_PKG_INSTALLED='apk --no-cache info -e'
 fi
 

--- a/scripts/self_check.sh
+++ b/scripts/self_check.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 ### Constants
-PLAT="$(grep -sEe '^NAME\=' /etc/os-release \
-  | sed -E -e "s/NAME\=[\'\"]?([^ ]*).*/\1/")"
+PLAT="$(grep -sEe '^NAME=' /etc/os-release \
+  | sed -E -e "s/NAME=[\'\"]?([^ ]*).*/\1/")"
 
 # dual protocol, VPN type supplied as $1
 VPN="${1}"

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -22,8 +22,8 @@ setupVarsFile="setupVars.conf"
 setupConfigDir="/etc/pivpn"
 pivpnFilesDir="/usr/local/src/pivpn"
 pivpnScriptDir="/opt/pivpn"
-PLAT="$(grep -sEe '^NAME\=' /etc/os-release \
-  | sed -E -e "s/NAME\=[\'\"]?([^ ]*).*/\1/")"
+PLAT="$(grep -sEe '^NAME=' /etc/os-release \
+  | sed -E -e "s/NAME=[\'\"]?([^ ]*).*/\1/")"
 UPDATE_PKG_CACHE="${PKG_MANAGER} update"
 
 ### Functions

--- a/scripts/wireguard/pivpn.sh
+++ b/scripts/wireguard/pivpn.sh
@@ -6,7 +6,7 @@ CHECK_PKG_INSTALLED='dpkg-query -s'
 scriptdir="/opt/pivpn"
 vpn="wireguard"
 
-if grep -qsEe "^NAME\=['\"]?Alpine[a-zA-Z ]*['\"]?$" /etc/os-release; then
+if test -f /etc/alpine-release && which apk > /dev/null; then
   CHECK_PKG_INSTALLED='apk --no-cache info -e'
 fi
 


### PR DESCRIPTION
Fixes an error on Alpine Linux caused by grep 3.12 when using unnecessary backslash. See https://github.com/pivpn/pivpn/issues/1935